### PR TITLE
Add support for FreeBSD

### DIFF
--- a/Dagon/DGPlatform.h
+++ b/Dagon/DGPlatform.h
@@ -52,7 +52,7 @@
 #define snprintf _snprintf
 #endif
 
-#elif __linux
+#elif __linux || defined(__FreeBSD__)
 
 #define DGPlatformLinux
 #include <X11/Xlib.h>              


### PR DESCRIPTION
Other than this, only Makefile changes (include/lib paths) are required to build the engine on FreeBSD. It seems to run as well, however frames are only changed when mouse is moved (e.g. when there're no input events, fps is frozen).
