### PR TITLE
Push critical fix to experimental.

### DIFF
--- a/Dagon/DGNode.cpp
+++ b/Dagon/DGNode.cpp
@@ -27,6 +27,7 @@ using namespace std;
 
 DGNode::DGNode() {
     _hasBundleName = false;
+    _hasFootstep = false;
     _isSlide = false;
     _slideReturn = 0;
     


### PR DESCRIPTION
hasFootstep was never initialized, which may have triggered playback of empty audio objects.
