### PR TITLE
Fix build under llvm

### DIFF
--- a/premake4.lua
+++ b/premake4.lua
@@ -93,7 +93,7 @@ solution "Dagon"
     
     -- Libraries required for Unix-based systems
     libs_unix = { "freetype", "GLEW", "GL", "GLU", "ogg", "openal", "vorbis",
-		  "vorbisfile", "theoradec", "SDL2" }
+		  "vorbisfile", "theoradec", "SDL2", "m", "stdc++" }
   
     -- Search for libraries on Linux systems
     if os.get() == "linux" then


### PR DESCRIPTION
llvm needs explicit linkage to libstdc++ (or -stdlib, but that introduces
compatibility issues with gcc) as well as libm.
