### PR TITLE
silence some maybe-uninitialized warnings on gcc

### DIFF
--- a/src/NodeProxy.h
+++ b/src/NodeProxy.h
@@ -112,7 +112,7 @@ public:
     lua_pushnil(L);
     while (lua_next(L, 1) != 0) {
       const char* key = lua_tostring(L, -2);
-      int dir;
+      int dir = kNorth;
       
       // We can only read the key as a string, so we have no choice but
       // do an ugly nesting of strcmps()

--- a/src/RenderManager.cpp
+++ b/src/RenderManager.cpp
@@ -387,6 +387,10 @@ void RenderManager::drawPolygon(std::vector<int> withArrayOfCoordinates, unsigne
         cy = 0.0f;
         cz = (GLfloat)center.y / (GLfloat)(cubeTextureSize >> 1);
         break;
+      default:
+        cx = 0.0f;
+        cy = 0.0f;
+        cz = 0.0f;
     }
     
     Vector vector = this->project(cx, cy, cz);


### PR DESCRIPTION
They appear when `-O2` is enabled.
