### PR TITLE
Save engine internals

### DIFF
--- a/src/Script.cpp
+++ b/src/Script.cpp
@@ -654,7 +654,7 @@ int Script::_globalPersist(lua_State *L) {
 
   Serializer save(L, file);
 
-  if (!save.writeHeader() || !save.writeGlobals()) {
+  if (!save.writeHeader() || !save.writeGlobals() || !save.writeRoomData()) {
     Log::instance().error(kModScript, "Error while saving: %s", SDL_GetError());
     remove(path.c_str());
     lua_pushboolean(L, false);

--- a/src/Serializer.h
+++ b/src/Serializer.h
@@ -37,6 +37,8 @@ class Serializer {
   bool writeGlobalField(const std::string &key, const std::string &val);
   // This assumes the table is at stack position -1
   std::string stringifyTable(const std::string parentKey);
+  // Callback for Lua when dumping a function
+  static int writeFunction(lua_State *L, const void *p, size_t sz, void *ud);
 
 public:
   Serializer(lua_State *L, SDL_RWops *rw);
@@ -44,6 +46,7 @@ public:
 
   bool writeHeader();
   bool writeGlobals();
+  bool writeRoomData();
 };
 
 }

--- a/src/TimerManager.cpp
+++ b/src/TimerManager.cpp
@@ -51,6 +51,26 @@ TimerManager::~TimerManager() {
 }
 
 ////////////////////////////////////////////////////////////
+// Implementation - Gets
+////////////////////////////////////////////////////////////
+
+std::vector<DGTimer> TimerManager::timers() {
+  return _arrayOfTimers;
+}
+
+double TimerManager::timeLeft(const DGTimer &timer) {
+  if (SDL_LockMutex(_mutex) == 0) {
+    double currentTime = SDL_GetTicks() / 1000;
+    double duration = currentTime - timer.lastTime;
+    double timeLeft = timer.trigger - duration;
+    SDL_UnlockMutex(_mutex);
+    return timeLeft;
+  }
+
+  return 0;
+}
+
+////////////////////////////////////////////////////////////
 // Implementation
 ////////////////////////////////////////////////////////////
 

--- a/src/TimerManager.h
+++ b/src/TimerManager.h
@@ -79,6 +79,12 @@ public:
     static TimerManager timerManager;
     return timerManager;
   }
+
+  // Gets
+  std::vector<DGTimer> timers();
+  double timeLeft(const DGTimer &timer); // How long until it (re)triggers?
+                                         // Caller should ensure that it makes sense to query this
+                                         // timer for it's remaining time.
   
   bool checkManual(int handle, int precision = 1000);
   int create(double trigger, bool shouldLoop, int handlerForLua, int luaObject = 0); // Returns a handle


### PR DESCRIPTION
This pull request extends my work in #119 by also writing the relevant internal engine data (what is required to recreate a sufficiently accurate representation of the current room) to the save file, in a format that is designed to allow for easy deserialization.