### PR TITLE
Fix timer saving

### DIFF
--- a/src/Serializer.cpp
+++ b/src/Serializer.cpp
@@ -145,6 +145,7 @@ int Serializer::writeFunction(lua_State *L, const void *p, size_t sz, void *ud) 
   SDL_RWops *rw = reinterpret_cast<SDL_RWops*>(ud);
   if (!SDL_RWwrite(rw, p, sz, 1))
     return 1;
+  return 0;
 }
 
 ////////////////////////////////////////////////////////////
@@ -341,6 +342,14 @@ bool Serializer::writeRoomData() {
 
     double timeLeft = TimerManager::instance().timeLeft(timer);
     if (timeLeft > 0) {
+      const std::string triggerStr = std::to_string(timer.trigger);
+      if (!SDL_WriteU8(_rw, timer.isLoopable))
+        return false;
+      if (!SDL_WriteU8(_rw, triggerStr.length()))
+        return false;
+      if (!SDL_RWwrite(_rw, triggerStr.c_str(), triggerStr.length(), 1))
+        return false;
+
       const std::string timerTime = std::to_string(timeLeft);
       if (!SDL_WriteU8(_rw, timerTime.length()))
         return false;


### PR DESCRIPTION
Fixes some bugs relating to timer saving introduced by  #124 
I forgot a return statement in the writeFunction Lua callback in case of no errors. Also forgot to save whether or not a timer is loopable and its original trigger time for recreating the timer.