### PR TITLE
Rework saving of Lua variables

### DIFF
--- a/src/Script.cpp
+++ b/src/Script.cpp
@@ -170,6 +170,10 @@ void Script::init() {
   lua_setfenv(_L, -2);
   
   lua_setglobal(_L, "effects");
+
+  // Create a table for game scripts to store data they want persisted
+  lua_newtable(_L);
+  lua_setglobal(_L, "dgPersistence");
   
   // Now we register the global functions that don't belong to any library
   _registerGlobals();
@@ -654,7 +658,7 @@ int Script::_globalPersist(lua_State *L) {
 
   Serializer save(L, file);
 
-  if (!save.writeHeader() || !save.writeGlobals() || !save.writeRoomData()) {
+  if (!save.writeHeader() || !save.writeScriptData() || !save.writeRoomData()) {
     Log::instance().error(kModScript, "Error while saving: %s", SDL_GetError());
     remove(path.c_str());
     lua_pushboolean(L, false);

--- a/src/Serializer.h
+++ b/src/Serializer.h
@@ -34,9 +34,9 @@ class Serializer {
 
   std::unordered_map<std::string, std::string> _tblMap;
 
-  bool writeGlobalField(const std::string &key, const std::string &val);
-  // This assumes the table is at stack position -1
-  std::string stringifyTable(const std::string parentKey);
+  bool writeField(const std::string &key, const std::string &val);
+  // This assumes a table is at stack position -1
+  int32_t writeTable(const std::string parentKey);
   // Callback for Lua when dumping a function
   static int writeFunction(lua_State *L, const void *p, size_t sz, void *ud);
 
@@ -45,7 +45,7 @@ public:
   ~Serializer();
 
   bool writeHeader();
-  bool writeGlobals();
+  bool writeScriptData();
   bool writeRoomData();
 };
 


### PR DESCRIPTION
Open the way to slimmer save files by allowing game developers to specify what they want saved by putting it in a table named `dgPersistence`. Hence this pull request changes Dagon's behaviour from attempting to save the entire global table (introduced in #119) to attempting to save just the aforementioned table.

I've also updated the save file format to a non-destructive one.
@agustincordes I did this in the way I discussed with you over email almost two weeks ago. I was able to do this because I think I have found a way to work around the issue of not knowing if it's safe to add to a table.
For the uninitiated, this change happened by converting what would have been `t={42}` into `dgPersistence["t"][1]=42`. This way, the loading of the save file will add to the table `t` rather than overwrite it. Thus, any data that might be in `t` but was not saved (because it is not supported) will still be intact after loading.