### PR TITLE
Fix table storing

### DIFF
--- a/src/Serializer.cpp
+++ b/src/Serializer.cpp
@@ -67,6 +67,7 @@ int32_t Serializer::writeTable(const std::string parentKey) {
   }
 
   { // Store this table
+    lua_pushvalue(_L, -1);
     int ref = luaL_ref(_L, LUA_REGISTRYINDEX);
     _tblMap[ref] = parentKey;
   }


### PR DESCRIPTION
This one is just downright embarrassing... in #127 I basically broke all of serialization by forgetting one line... I forgot that creating a Lua reference pops the value from the stack. Can you imagine how hard I panicked when I thought it was the new deserialization I've been working on all day that caused that?
Please merge ASAP and let me forget about it forever....