### PR TITLE
Fix saving in Node with empty description

### DIFF
--- a/src/Deserializer.cpp
+++ b/src/Deserializer.cpp
@@ -78,31 +78,25 @@ std::string Deserializer::roomName() {
 
 bool Deserializer::readHeader() {
   { // Read Dagon version string
-    uint8_t len;
-    if (!(len = SDL_ReadU8(_rw)))
-      return false;
+    uint8_t len = SDL_ReadU8(_rw);
     std::vector<uint8_t> buf(len);
-    if (!SDL_RWread(_rw, buf.data(), buf.capacity(), 1))
+    if (len > 0 && !SDL_RWread(_rw, buf.data(), buf.capacity(), 1))
       return false;
     _dgVersion = std::string(buf.begin(), buf.end());
   }
 
   { // Read preview text
-    uint8_t len;
-    if (!(len = SDL_ReadU8(_rw)))
-      return false;
+    uint8_t len = SDL_ReadU8(_rw);
     std::vector<uint8_t> buf(len);
-    if (!SDL_RWread(_rw, buf.data(), buf.capacity(), 1))
+    if (len > 0 && !SDL_RWread(_rw, buf.data(), buf.capacity(), 1))
       return false;
     _preview = std::string(buf.begin(), buf.end());
   }
 
   { // Read Room name
-    uint8_t len;
-    if (!(len = SDL_ReadU8(_rw)))
-      return false;
+    uint8_t len = SDL_ReadU8(_rw);
     std::vector<uint8_t> buf(len);
-    if (!SDL_RWread(_rw, buf.data(), buf.capacity(), 1))
+    if (len > 0 && !SDL_RWread(_rw, buf.data(), buf.capacity(), 1))
       return false;
     _roomName = std::string(buf.begin(), buf.end());
   }

--- a/src/Script.cpp
+++ b/src/Script.cpp
@@ -656,21 +656,24 @@ int Script::_globalPersist(lua_State *L) {
 
   if (!(file = SDL_RWFromFile(path.c_str(), "wb"))) {
     Log::instance().error(kModScript, "Can't open save file for writing: %s", SDL_GetError());
-    remove(path.c_str());
     lua_pushboolean(L, false);
     return 1;
   }
 
-  Serializer save(L, file);
+  { // Scope to ensure file is closed before going to SAVE_ERROR
+    Serializer save(L, file);
 
-  if (!save.writeHeader() || !save.writeScriptData() || !save.writeRoomData()) {
-    Log::instance().error(kModScript, "Error while saving: %s", SDL_GetError());
-    remove(path.c_str());
-    lua_pushboolean(L, false);
-    return 1;
+    if (!save.writeHeader() || !save.writeScriptData() || !save.writeRoomData())
+      goto SAVE_ERROR;
   }
 
   lua_pushboolean(L, true);
+  return 1;
+
+SAVE_ERROR:
+  Log::instance().error(kModScript, "Error while saving: %s", SDL_GetError());
+  remove(path.c_str());
+  lua_pushboolean(L, false);
   return 1;
 }
 

--- a/src/Script.cpp
+++ b/src/Script.cpp
@@ -701,19 +701,13 @@ int Script::_globalUnpersist(lua_State *L) {
 
   // Create new room from file. Remove existing room first.
   lua_getglobal(L, loader.roomName().c_str());
-  if (DGCheckProxy(L, -1) == kObjectRoom) {
-    Room *oldRoom = ProxyToRoom(L, -1);
-    lua_pop(L, 1); // Pop Room.
+  Room *oldRoom = ProxyToRoom(L, -1);
+  lua_pop(L, 1);
 
-    Script::instance()._loadRoomFile(L, loader.roomName().c_str());
+  Script::instance()._loadRoomFile(L, loader.roomName().c_str());
 
-    if (oldRoom)
-      Control::instance().replaceRoom(oldRoom);
-  }
-  else {
-    lua_pop(L, 1); // Pop Room.
-    Script::instance()._loadRoomFile(L, loader.roomName().c_str());
-  }
+  if (oldRoom)
+    Control::instance().replaceRoom(oldRoom);
 
   // Load Lua variables.
   if (!loader.readScriptData()) {

--- a/src/Serializer.cpp
+++ b/src/Serializer.cpp
@@ -159,7 +159,7 @@ bool Serializer::writeHeader() {
 
     if (!SDL_WriteU8(_rw, len))
       return false;
-    if (!SDL_RWwrite(_rw, desc.c_str(), len, 1))
+    if (len > 0 && !SDL_RWwrite(_rw, desc.c_str(), len, 1))
       return false;
   }
 


### PR DESCRIPTION
The first part of this is just kinda funny. `SDL_RWwrite` (and friends) will return the number of objects written so if the description string is empty when saving in a Node, it will correctly return zero which is then evaluated as false by C++ which causes it to abandon the save.

Also undoes 12fb99f41dbc591dffddd9881bbbb7481bbf0bdf as it apparently breaks loading. I have absolutely no idea why though, but the changes in that commit cause the engine to crash at https://github.com/bd339/Dagon/blob/master/src/Script.cpp#L727 when switching rooms. It probably has to do with `DGCheckProxy` not doing what I expect it to. It returns 1 (`kObjectGeneric`) for something I am certain ought to be a Room. Please enlighten me someone.