### PR TITLE
Persist field of view

### DIFF
--- a/src/Deserializer.cpp
+++ b/src/Deserializer.cpp
@@ -246,6 +246,25 @@ bool Deserializer::adjustCamera() {
     Log::instance().warning(kModScript, "Unable to parse vertical angle: %s", vAngleStr);
   }
 
+  uint8_t fovLen = SDL_ReadU8(_rw);
+  std::vector<uint8_t> fovBuf(fovLen);
+  if (!SDL_RWread(_rw, fovBuf.data(), fovBuf.capacity(), 1))
+    return false;
+  const std::string fovStr(fovBuf.begin(), fovBuf.end());
+
+  try {
+    float fov = std::stof(fovStr);
+    bool lock = CameraManager::instance().isLocked();
+    if (lock)
+      CameraManager::instance().unlock();
+    CameraManager::instance().setFieldOfView(fov);
+    if (lock)
+      CameraManager::instance().lock();
+  }
+  catch (std::exception &e) {
+    Log::instance().warning(kModScript, "Unable to parse field of view: %s", fovStr);
+  }
+
   return true;
 }
 

--- a/src/Serializer.cpp
+++ b/src/Serializer.cpp
@@ -257,6 +257,13 @@ bool Serializer::writeRoomData() {
   if (!SDL_RWwrite(_rw, vAngleStr.c_str(), vAngleStr.length(), 1))
     return false;
 
+  float fov = CameraManager::instance().fieldOfView();
+  const std::string fovStr = std::to_string(fov);
+  if (!SDL_WriteU8(_rw, fovStr.length()))
+    return false;
+  if (!SDL_RWwrite(_rw, fovStr.c_str(), fovStr.length(), 1))
+    return false;
+
   // Write audio states
   if (!SDL_WriteBE16(_rw, room->arrayOfAudios().size()))
     return false;


### PR DESCRIPTION
By doing more testing in the Seclusion demo, I discovered that sometimes the field of view changes and loading might then cause black bars to appear around the edge of the viewport.