### PR TITLE
Persist/unpersist callbacks

### DIFF
--- a/src/Node.cpp
+++ b/src/Node.cpp
@@ -33,6 +33,8 @@ Node::Node() {
   _hasFootstep = false;
   _hasEnterEvent = false;
   _hasLeaveEvent = false;
+  _hasPersistEvent = false;
+  _hasUnpersistEvent = false;
   _isSlide = false;
   _parentRoom = 0;
   _slideReturn = 0;
@@ -95,6 +97,14 @@ int Node::slideReturn() {
   return _slideReturn;
 }
 
+bool Node::hasPersistEvent() {
+  return _hasPersistEvent;
+}
+
+bool Node::hasUnpersistEvent() {
+  return _hasUnpersistEvent;
+}
+
 ////////////////////////////////////////////////////////////
 // Implementation - Gets
 ////////////////////////////////////////////////////////////
@@ -138,6 +148,16 @@ size_t Node::numSpots() {
   return _arrayOfSpots.size();
 }
 
+int Node::persistEvent() {
+  assert(_hasPersistEvent == true);
+  return _luaPersistRef;
+}
+
+int Node::unpersistEvent() {
+  assert(_hasUnpersistEvent == true);
+  return _luaUnpersistRef;
+}
+
 ////////////////////////////////////////////////////////////
 // Implementation - Sets
 ////////////////////////////////////////////////////////////
@@ -179,6 +199,16 @@ void Node::setSlide(bool enabled) {
 
 void Node::setSlideReturn(int luaHandler) {
   _slideReturn = luaHandler;
+}
+
+void Node::setPersistEvent(const int luaRef) {
+  _hasPersistEvent = true;
+  _luaPersistRef = luaRef;
+}
+
+void Node::setUnpersistEvent(const int luaRef) {
+  _hasUnpersistEvent = true;
+  _luaUnpersistRef = luaRef;
 }
 
 ////////////////////////////////////////////////////////////

--- a/src/Node.h
+++ b/src/Node.h
@@ -49,6 +49,8 @@ class Node : public Object {
   bool hasLeaveEvent();
   bool hasSpots();
   bool isSlide();
+  bool hasPersistEvent();
+  bool hasUnpersistEvent();
   
   // Gets
   std::string bundleName();
@@ -61,6 +63,8 @@ class Node : public Object {
   Node* previousNode();
   size_t numSpots();
   int slideReturn();
+  int persistEvent();
+  int unpersistEvent();
   
   // Sets
   void setBundleName(std::string theName);
@@ -72,6 +76,8 @@ class Node : public Object {
   void setPreviousNode(Node* node);
   void setSlide(bool enabled);
   void setSlideReturn(int luaHandler);
+  void setPersistEvent(const int luaRef);
+  void setUnpersistEvent(const int luaRef);
   
   // State changes
   void addCustomLink(unsigned int withDirection, int luaHandler);
@@ -99,6 +105,10 @@ class Node : public Object {
   int _luaEnterReference;
   int _luaLeaveReference;
   int _slideReturn;
+  bool _hasPersistEvent;
+  int _luaPersistRef;
+  bool _hasUnpersistEvent;
+  int _luaUnpersistRef;
   
   void _link(unsigned int direction, Action* action);
   

--- a/src/NodeProxy.h
+++ b/src/NodeProxy.h
@@ -166,6 +166,31 @@ public:
     
     return 0;
   }
+
+  int onPersist(lua_State *L) {
+    if (!lua_isfunction(L, 1)) {
+      Log::instance().trace(kModScript, kString14009);
+      return 0;
+    }
+
+    int ref = luaL_ref(L, LUA_REGISTRYINDEX); // pop and return a reference to the table.
+    n->setPersistEvent(ref);
+
+    return 0;
+  }
+
+  int onUnpersist(lua_State *L) {
+    if (!lua_isfunction(L, 1)) {
+      Log::instance().trace(kModScript, kString14009);
+      return 0;
+    }
+
+    lua_pushvalue(L, 1);
+    int ref = luaL_ref(L, LUA_REGISTRYINDEX); // pop and return a reference to the table.
+    n->setUnpersistEvent(ref);
+
+    return 0;
+  }
   
   // Set a custom footstep
   int setFootstep(lua_State *L) {
@@ -205,6 +230,8 @@ Luna<NodeProxy>::RegType NodeProxy::methods[] = {
   method(NodeProxy, link),
   method(NodeProxy, onEnter),
   method(NodeProxy, onLeave),
+  method(NodeProxy, onPersist),
+  method(NodeProxy, onUnpersist),
   method(NodeProxy, setFootstep),
   {0,0}
 };

--- a/src/Room.cpp
+++ b/src/Room.cpp
@@ -32,6 +32,8 @@ Room::Room() {
   _hasDefaultFootstep = false;
   _hasEffects = false;
   _hasEnterEvent = false;
+  _hasPersistEvent = false;
+  _hasUnpersistEvent = false;
   this->setType(kObjectRoom);
 }
 
@@ -60,6 +62,14 @@ bool Room::hasNodes() {
   return !_arrayOfNodes.empty();
 }
 
+bool Room::hasPersistEvent() {
+  return _hasPersistEvent;
+}
+
+bool Room::hasUnpersistEvent() {
+  return _hasUnpersistEvent;
+}
+
 ////////////////////////////////////////////////////////////
 // Implementation - Gets
 ////////////////////////////////////////////////////////////
@@ -84,6 +94,16 @@ SettingCollection Room::effects() {
 int Room::enterEvent() {
   assert(_hasEnterEvent = true);
   return _luaReference;
+}
+
+int Room::persistEvent() {
+  assert(_hasPersistEvent == true);
+  return _persistReference;
+}
+
+int Room::unpersistEvent() {
+  assert(_hasUnpersistEvent == true);
+  return _unpersistReference;
 }
 
 size_t Room::numNodes() {
@@ -112,6 +132,16 @@ void Room::setEffects(const SettingCollection& theEffects) {
 void Room::setEnterEvent(int luaReference) {
   _hasEnterEvent = true;
   _luaReference = luaReference;
+}
+
+void Room::setPersistEvent(const int luaRef) {
+  _hasPersistEvent = true;
+  _persistReference = luaRef;
+}
+
+void Room::setUnpersistEvent(const int luaRef) {
+  _hasUnpersistEvent = true;
+  _unpersistReference = luaRef;
 }
 
 ////////////////////////////////////////////////////////////

--- a/src/Room.h
+++ b/src/Room.h
@@ -44,6 +44,8 @@ class Room : public Object {
   bool hasDefaultFootstep();
   bool hasEffects();
   bool hasNodes();
+  bool hasPersistEvent();
+  bool hasUnpersistEvent();
   
   // Gets
   std::vector<Audio*> arrayOfAudios();
@@ -51,11 +53,15 @@ class Room : public Object {
   Audio* defaultFootstep();
   SettingCollection effects();
   int enterEvent();
+  int persistEvent();
+  int unpersistEvent();
   size_t numNodes();
   
   // Sets
   void setDefaultFootstep(Audio* theFootstep);
   void setEffects(const SettingCollection& theEffects);
+  void setPersistEvent(const int luaRef);
+  void setUnpersistEvent(const int luaRef);
   
   // State changes
   Audio* addAudio(Audio* anAudio);
@@ -82,6 +88,10 @@ class Room : public Object {
   bool _hasEffects;
   bool _hasEnterEvent;
   int _luaReference;
+  bool _hasPersistEvent;
+  int _persistReference;
+  bool _hasUnpersistEvent;
+  int _unpersistReference;
   
   Room(const Room&);
   void operator=(const Room&);

--- a/src/RoomProxy.h
+++ b/src/RoomProxy.h
@@ -169,6 +169,31 @@ public:
     
     return 1;
   }
+
+  int onPersist(lua_State *L) {
+    if (!lua_isfunction(L, 1)) {
+      Log::instance().trace(kModScript, kString14009);
+      return 0;
+    }
+
+    int ref = luaL_ref(L, LUA_REGISTRYINDEX); // pop and return a reference to the table.
+    r->setPersistEvent(ref);
+
+    return 0;
+  }
+
+  int onUnpersist(lua_State *L) {
+    if (!lua_isfunction(L, 1)) {
+      Log::instance().trace(kModScript, kString14009);
+      return 0;
+    }
+    
+    lua_pushvalue(L, 1);
+    int ref = luaL_ref(L, LUA_REGISTRYINDEX); // pop and return a reference to the table.
+    r->setUnpersistEvent(ref);
+
+    return 0;
+  }
   
   Room* ptr() { return r; }
   
@@ -192,6 +217,8 @@ Luna<RoomProxy>::RegType RoomProxy::methods[] = {
   method(RoomProxy, setDefaultFootstep),
   method(RoomProxy, setEffects),
   method(RoomProxy, startTimer),
+  method(RoomProxy, onPersist),
+  method(RoomProxy, onUnpersist),
   {0,0}
 };
   


### PR DESCRIPTION
Consider a Room simply named `Room`. It will now be possible to do

`Room:onPersist(function()
  -- do room specific stuff here
end)`

There is also an equivalent `onUnpersist` callback. The same callbacks are also added to Nodes. The motivation was to make the system more flexible but also to give game developers an opportunity to make up for possible shortcomings they encounter in the save system.

The `onPersist` callbacks for Nodes and Rooms are called just before Lua data is written to the save file (right after the header). Room callback first and then node callback follows immediately after.

The `onUnpersist` callback for a Room is called just after switching to that Room and the `onUnpersist` callback for Nodes is called just after switching to that node.