### PR TITLE
Add magic number to save files

### DIFF
--- a/src/Deserializer.cpp
+++ b/src/Deserializer.cpp
@@ -29,6 +29,8 @@
 
 namespace dagon {
 
+const char SAVIdent[] = { '\x44', '\x41', '\x47', '\x4F', '\x4E', '\x53', '\x41', '\x56', '\x45' };
+
 ////////////////////////////////////////////////////////////
 // Implementation - Constructor & Destructor
 ////////////////////////////////////////////////////////////
@@ -77,6 +79,16 @@ std::string Deserializer::roomName() {
 ////////////////////////////////////////////////////////////
 
 bool Deserializer::readHeader() {
+  { // Read magic number
+    char buf[sizeof(SAVIdent)];
+    if (!SDL_RWread(_rw, buf, sizeof(SAVIdent), 1))
+      return false;
+    if (std::memcmp(SAVIdent, buf, sizeof(SAVIdent)) != 0) {
+      Log::instance().error(kModScript, "Unexpected magic number. This is not a Dagon save file.");
+      return false;
+    }
+  }
+
   { // Read Dagon version string
     uint8_t len = SDL_ReadU8(_rw);
     std::vector<uint8_t> buf(len);

--- a/src/Serializer.cpp
+++ b/src/Serializer.cpp
@@ -30,6 +30,8 @@
 
 namespace dagon {
 
+const char SAVIdent[] = { '\x44', '\x41', '\x47', '\x4F', '\x4E', '\x53', '\x41', '\x56', '\x45' };
+
 ////////////////////////////////////////////////////////////
 // Implementation - Constructor & Destructor
 ////////////////////////////////////////////////////////////
@@ -142,6 +144,10 @@ int Serializer::writeFunction(lua_State *L, const void *p, size_t sz, void *ud) 
 ////////////////////////////////////////////////////////////
 
 bool Serializer::writeHeader() {
+  // Write magic number
+  if (!SDL_RWwrite(_rw, SAVIdent, sizeof(SAVIdent), 1))
+    return false;
+
   // Write version information
   {
     const size_t len = UCHAR_MAX > strlen(DAGON_VERSION_STRING) ? strlen(DAGON_VERSION_STRING) :


### PR DESCRIPTION
Add a 9 byte identifier to the beginning of each save file, so we can verify that the file we are trying to load is likely a save file produced by Dagon and not of some unknown origin.