### PR TITLE
Merge Rooms when possible

### DIFF
--- a/src/Control.cpp
+++ b/src/Control.cpp
@@ -44,8 +44,6 @@
 #include "TimerManager.h"
 #include "VideoManager.h"
 
-#include <algorithm>
-
 namespace dagon {
 
 ////////////////////////////////////////////////////////////
@@ -1022,12 +1020,6 @@ size_t Control::numRooms() {
 
 std::vector<Room*> Control::rooms() {
   return _arrayOfRooms;
-}
-
-void Control::replaceRoom(Room *replacee) {
-  Room *replacement = _arrayOfRooms.back();
-  std::replace(_arrayOfRooms.begin(), _arrayOfRooms.end(), replacee, replacement);
-  _arrayOfRooms.pop_back();
 }
 
 ////////////////////////////////////////////////////////////

--- a/src/Control.h
+++ b/src/Control.h
@@ -160,7 +160,6 @@ public:
   void update();
   size_t numRooms();
   std::vector<Room*> rooms();
-  void replaceRoom(Room *replacee);
 };
   
 }

--- a/src/Script.cpp
+++ b/src/Script.cpp
@@ -716,13 +716,11 @@ int Script::_globalUnpersist(lua_State *L) {
   Room *oldRoom = ProxyToRoom(L, -1);
   lua_pop(L, 1);
 
-  Script::instance()._loadRoomFile(L, loader.roomName().c_str());
+  if (!oldRoom) { // Room doesn't exist. Create it.
+    Script::instance()._loadRoomFile(L, loader.roomName().c_str());
+  }
 
-  if (oldRoom)
-    Control::instance().replaceRoom(oldRoom);
-
-  // Load Lua variables.
-  if (!loader.readScriptData()) {
+  if (!loader.readScriptData()) { // Load Lua variables.
     Log::instance().error(kModScript, "Error loading Lua data! %s", SDL_GetError());
     lua_pushboolean(L, false);
     return 1;


### PR DESCRIPTION
Until now, whenever you load into a Room that already exists in the engine, it would create a new Room and remove the old Room from the list of Rooms. Now it will merge the save file's data with the existing Room and only create a new Room if the Room we are loading into doesn't exist yet.