### PR TITLE
Rewind start time on original timer, not copy

### DIFF
--- a/src/TimerManager.cpp
+++ b/src/TimerManager.cpp
@@ -54,7 +54,7 @@ TimerManager::~TimerManager() {
 // Implementation - Gets
 ////////////////////////////////////////////////////////////
 
-std::vector<DGTimer> TimerManager::timers() {
+std::vector<DGTimer>& TimerManager::timers() {
   return _arrayOfTimers;
 }
 

--- a/src/TimerManager.h
+++ b/src/TimerManager.h
@@ -81,7 +81,8 @@ public:
   }
 
   // Gets
-  std::vector<DGTimer> timers();
+  std::vector<DGTimer>& timers(); // THIS BREAKS ENCAPSULATION.
+                                  // Make sure you don't mutate the vector on accident.
   double timeElapsed(const DGTimer &timer); // How long since it was started?
                                             // Caller should ensure it makes sense to query
                                             // this timer for it's elapsed time.


### PR DESCRIPTION
Before we were returning the vector of timers as a copy, so the Deserializer was rewinding time on a copy of a timer. Fixed (in an ugly way) by returning a reference to the member instead of a copy.
Btw, the timer code is completely untested as Seclusion doesn't use it atm so I expect it to break horrendously first time someone actually needs it...