### PR TITLE
Correct behaviour for Slide persistence

### DIFF
--- a/src/Deserializer.cpp
+++ b/src/Deserializer.cpp
@@ -179,6 +179,24 @@ Node *Deserializer::readNode() {
   return nullptr;
 }
 
+void Deserializer::restorePreviousNodes() {
+  uint16_t numSlides = SDL_ReadBE16(_rw);
+  for (uint16_t i = 0; i < numSlides; i++) {
+    uint64_t hash = SDL_ReadBE64(_rw);
+    uint64_t prevHash = SDL_ReadBE64(_rw);
+
+    try {
+      Node *node = static_cast<Node*>(Control::instance().invObjMap.at(hash));
+      Node *prevNode = static_cast<Node*>(Control::instance().invObjMap.at(prevHash));
+      node->setPreviousNode(prevNode);
+    }
+    catch (std::out_of_range &e) {
+      Log::instance().warning(kModScript,
+        "No matching Node pair for hash pair %u and %u", hash, prevHash);
+    }
+  }
+}
+
 bool Deserializer::adjustCamera() {
   uint8_t hAngleLen = SDL_ReadU8(_rw);
   std::vector<uint8_t> hAngleBuf(hAngleLen);

--- a/src/Deserializer.h
+++ b/src/Deserializer.h
@@ -59,6 +59,7 @@ public:
   bool readScriptData();
   void toggleSpots();
   Node *readNode();
+  void restorePreviousNodes();
   bool adjustCamera();
   void toggleAudio();
   bool readTimers();

--- a/src/Script.cpp
+++ b/src/Script.cpp
@@ -793,6 +793,9 @@ int Script::_globalUnpersist(lua_State *L) {
   if (newNode && newNode->hasUnpersistEvent())
     Script::instance().processCallback(newNode->unpersistEvent(), 0);
 
+  // Restore previous Node for Slides.
+  loader.restorePreviousNodes();
+
   if (!loader.adjustCamera()) {
     Log::instance().error(kModScript, "Error adjusting camera! %s", SDL_GetError());
     lua_pushboolean(L, false);


### PR DESCRIPTION
It has never been a problem to save in a Slide and return the player to that Slide, but because the previous node was never saved it could switch you to an unexpected Node when you exit the Slide. Nothing gamebreaking for Serena for example, but once games allow you to load from a main menu things can get really screwy when you return to the "main menu Node" when exiting the Slide you loaded into, for example.
I've been holding off on this patch because Seclusion uses it own code to switch to and from Slides (this patch shouldn't break that) but this patch seems to provide the correct behaviour for Serena at least.