### PR TITLE
Fix occasional™ shutdown crash

### DIFF
--- a/src/Node.cpp
+++ b/src/Node.cpp
@@ -15,6 +15,7 @@
 // Headers
 ////////////////////////////////////////////////////////////
 
+#include <algorithm>
 #include <cassert>
 
 #include "Audio.h"
@@ -48,21 +49,11 @@ Node::Node() {
 Node::~Node() {
   // Note that we only delete spots automatically created by this class,
   // not ones by the user
-  bool done = false;
-  while (!done) {
-	_it = _arrayOfSpots.begin();
-    done = true;
-    while ((_it != _arrayOfSpots.end())) {
-		Spot* spot = (*_it);
-        if (spot->hasFlag(kSpotClass)) {
-		  // FIXME: Class spots should be in a different vector
-		  //delete spot;
-		  _arrayOfSpots.erase(_it);
-          done = false;
-          break;
-        } else ++_it;
-    }
-  }
+  // FIXME: Class spots should be in a different vector
+  _arrayOfSpots.erase(std::remove_if(_arrayOfSpots.begin(),
+                                     _arrayOfSpots.end(),
+                                     [](Spot *spot) { return spot->hasFlag(kSpotClass); }),
+                      _arrayOfSpots.end());
 }
 
 ////////////////////////////////////////////////////////////


### PR DESCRIPTION
Once in a Blue Moon (okay, slightly more often), Dagon would crash on shutdown from calling a method on an invalid Spot pointer.

Seeing this, imagine how sexy it would be if modern C++ like this was available when the majority of Dagon's code was written.