### PR TITLE
Only look for user created Spots

### DIFF
--- a/src/Serializer.cpp
+++ b/src/Serializer.cpp
@@ -228,17 +228,19 @@ bool Serializer::writeRoomData() {
           do {
             Spot *spot = node->currentSpot();
 
-            try {
-              size_t hash = Control::instance().objMap.at(spot);
-              if (!SDL_WriteBE64(_rw, hash))
-                return false;
-              if (!SDL_WriteU8(_rw, spot->isEnabled()))
-                return false;
-              numSpots++;
-            }
-            catch (std::out_of_range &e) {
-              Log::instance().warning(kModScript,
-                "No object mapping for Spot. Spot state not saved.");
+            if (spot->hasFlag(kSpotUser)) {
+              try {
+                size_t hash = Control::instance().objMap.at(spot);
+                if (!SDL_WriteBE64(_rw, hash))
+                  return false;
+                if (!SDL_WriteU8(_rw, spot->isEnabled()))
+                  return false;
+                numSpots++;
+              }
+              catch (std::out_of_range &e) {
+                Log::instance().warning(kModScript,
+                  "No object mapping for Spot. Spot state not saved.");
+              }
             }
           } while (node->iterateSpots());
         }


### PR DESCRIPTION
Previously the Spots automatically created by Dagon by it's Node linking feature were also looked for in the object map. This filled the log with plenty of red herrings, warning about plenty of Spots that will not have their state saved.