### PR TITLE
Include coordinates in unmapped Spot warning

### DIFF
--- a/src/Serializer.cpp
+++ b/src/Serializer.cpp
@@ -238,7 +238,7 @@ bool Serializer::writeRoomData() {
             }
             catch (std::out_of_range &e) {
               Log::instance().warning(kModScript,
-                "No object mapping for Spot. Spot state not saved.");
+                "No object mapping for Spot{%s}. State not saved.", spot->stringifyCoords().c_str());
             }
           } while (node->iterateSpots());
         }

--- a/src/Spot.cpp
+++ b/src/Spot.cpp
@@ -15,7 +15,10 @@
 // Headers
 ////////////////////////////////////////////////////////////
 
+#include <algorithm>
 #include <cstdlib>
+#include <iterator>
+#include <sstream>
 
 #include "Audio.h"
 #include "Group.h"
@@ -138,6 +141,13 @@ Video* Spot::video() {
 
 float Spot::volume() {
   return _volume;
+}
+
+std::string Spot::stringifyCoords() const {
+  std::stringstream coordStr;
+  std::copy(_arrayOfCoordinates.begin(), std::prev(_arrayOfCoordinates.end()),
+            std::ostream_iterator<int>(coordStr, ", "));
+  return coordStr.str() + std::to_string(_arrayOfCoordinates.back());
 }
 
 ////////////////////////////////////////////////////////////

--- a/src/Spot.h
+++ b/src/Spot.h
@@ -73,6 +73,7 @@ class Spot : public Object {
   int vertexCount();
   Video* video();
   float volume();
+  std::string stringifyCoords() const;
   
   // Sets
   void setAction(Action* anAction);


### PR DESCRIPTION
Currently this warning is our best indication that a user has name duplicates, so it should include the coordinates of the Spot in question to make it easier to determine if and where multiple Spots are assigned to the same variable by searching across their script files (editors like Notepad++ allow this) for those coordinates.