### PR TITLE
Update Control.cpp

### DIFF
--- a/src/Control.cpp
+++ b/src/Control.cpp
@@ -691,7 +691,7 @@ void Control::switchTo(Object* theTarget) {
           }
           
           if (_directControlActive)
-            _directControlActive = false;
+           // _directControlActive = false;
           
           cameraManager.lock();
         }


### PR DESCRIPTION
This update prevents the Direct Control from being disabled by engine in a Slide. Basically it will break the default behavior and camera will still be moving in Slides. 

This is only relevant/necessary for Seclusion. 