### PR TITLE
Change audio behaviour when switching nodes

### DIFF
--- a/src/Control.cpp
+++ b/src/Control.cpp
@@ -739,7 +739,7 @@ void Control::switchTo(Object* theTarget) {
 
           do {
             Spot *curSpot = curNode->currentSpot();
-            if (curSpot->hasAudio() && curSpot->audio()->doesAutoplay()) {
+            if (curSpot->hasAudio() && curSpot->hasFlag(kSpotAuto)) {
               curNodeAudios.insert(curSpot->audio());
             }
           } while (curNode->iterateSpots());
@@ -753,7 +753,7 @@ void Control::switchTo(Object* theTarget) {
 
           do {
             Spot *targetspot = node->currentSpot();
-            if (targetspot->hasAudio() && targetspot->audio()->doesAutoplay()) {
+            if (targetspot->hasAudio() && targetspot->hasFlag(kSpotAuto)) {
               targetNodeAudios.insert(targetspot->audio());
             }
           } while (node->iterateSpots());


### PR DESCRIPTION
Tries to resolve the discussion in #147. It does this by only affecting room specific audio when switching rooms and when switching nodes it will add all of the autoplaying audio objects attached to spots of the target node to a set: `targetNodeAudios` and all of the autoplaying audio objects attached to spots of the current node will be added to a set: `curNodeAudios`. To find out which audio objects should stop playing the set difference `curNodeAudios \ targetNodeAudios` will be computed (the resulting set will be the set of all audio objects in `curNodeAudios` but not in `targetNodeAudios`). When deciding what audios should begin playing when we switch to the new node, the set difference `targetNodeAudios \ curNodeAudios` will be computed (the resulting set will be the set of all audio objects in `targetNodeAudios` but not in `curNodeAudios`).