### PR TITLE
Only release audio resources on room change

### DIFF
--- a/src/AudioManager.cpp
+++ b/src/AudioManager.cpp
@@ -223,6 +223,20 @@ void AudioManager::registerAudio(Audio* target) {
   _arrayOfAudios.push_back(target);
 }
 
+void AudioManager::deactivateAudio(Audio* target) {
+  if (SDL_LockMutex(_mutex) == 0) {
+    auto it = std::find(_arrayOfActiveAudios.begin(), _arrayOfActiveAudios.end(), target);
+    if (it != _arrayOfActiveAudios.end()) {
+      _arrayOfActiveAudios.erase(it);
+    }
+
+    SDL_UnlockMutex(_mutex);
+  }
+  else {
+    log.error(kModAudio, "%s", kString18002);
+  }
+}
+
 void AudioManager::requestAudio(Audio* target) {
   if (_arrayOfActiveAudios.size() >= kMaxNumberOfAudios) 
 	  return;
@@ -300,6 +314,7 @@ void AudioManager::unloadPending() {
   for (auto it = _pendingUnload.begin(); it != _pendingUnload.end();) {
     if (!(*it)->isPlaying()) {
       (*it)->unload();
+      deactivateAudio(*it);
       it = _pendingUnload.erase(it);
     }
     else {

--- a/src/AudioManager.cpp
+++ b/src/AudioManager.cpp
@@ -292,6 +292,19 @@ void AudioManager::terminate() {
   }
 }
 
+void AudioManager::pendingUnload(Audio *target) {
+  _pendingUnload.push_back(target);
+}
+
+void AudioManager::unloadPending() {
+  for (auto it = _pendingUnload.begin(); it != _pendingUnload.end(); ++it) {
+    if (!(*it)->isPlaying()) {
+      (*it)->unload();
+      _pendingUnload.erase(it);
+    }
+  }
+}
+
 // Asynchronous method
 bool AudioManager::update() {
   if (_isRunning) {

--- a/src/AudioManager.cpp
+++ b/src/AudioManager.cpp
@@ -297,10 +297,13 @@ void AudioManager::pendingUnload(Audio *target) {
 }
 
 void AudioManager::unloadPending() {
-  for (auto it = _pendingUnload.begin(); it != _pendingUnload.end(); ++it) {
+  for (auto it = _pendingUnload.begin(); it != _pendingUnload.end();) {
     if (!(*it)->isPlaying()) {
       (*it)->unload();
-      _pendingUnload.erase(it);
+      it = _pendingUnload.erase(it);
+    }
+    else {
+      ++it;
     }
   }
 }

--- a/src/AudioManager.h
+++ b/src/AudioManager.h
@@ -85,6 +85,7 @@ public:
   
   void init();
   void registerAudio(Audio* target);
+  void deactivateAudio(Audio* target);
   void requestAudio(Audio* target);
   void setOrientation(float* orientation);
   void terminate();

--- a/src/AudioManager.h
+++ b/src/AudioManager.h
@@ -58,6 +58,7 @@ class AudioManager {
   
   std::vector<Audio*> _arrayOfAudios;
   std::vector<Audio*> _arrayOfActiveAudios;
+  std::vector<Audio*> _pendingUnload;
   
   bool _isInitialized;
   bool _isRunning;
@@ -87,6 +88,8 @@ public:
   void requestAudio(Audio* target);
   void setOrientation(float* orientation);
   void terminate();
+  void pendingUnload(Audio *target);
+  void unloadPending();
   bool update();
 };
   

--- a/src/Control.cpp
+++ b/src/Control.cpp
@@ -665,6 +665,7 @@ void Control::switchTo(Object* theTarget) {
           }
           else {
             audio->unload();
+            audioManager.deactivateAudio(audio);
           }
         }
 
@@ -963,6 +964,7 @@ void Control::switchTo(Object* theTarget) {
   
   //log.trace(kModControl, "Flushing audio...");
   
+  audioManager.flush();
   cameraManager.stopPanning();
   
   //log.trace(kModControl, "Done!");

--- a/src/Control.cpp
+++ b/src/Control.cpp
@@ -658,7 +658,14 @@ void Control::switchTo(Object* theTarget) {
         std::set_difference(curRoomAudios.begin(), curRoomAudios.end(), nextRoomAudios.begin(),
                             nextRoomAudios.end(), std::back_inserter(audiosToBeUnloaded));
         for (Audio *audio : audiosToBeUnloaded) {
-          audio->unload();
+          if (audio->isPlaying()) {
+            audio->setFadeSpeed(kFadeSlow);
+            audio->fadeOut();
+            audioManager.pendingUnload(audio);
+          }
+          else {
+            audio->unload();
+          }
         }
 
         //log.trace(kModControl, "Set room and Lua objet");
@@ -742,6 +749,8 @@ void Control::switchTo(Object* theTarget) {
         //log.trace(kModControl, "Switching to node...");
         if (currentNode()->isSlide())
           cameraManager.unlock();
+
+        audioManager.unloadPending();
         
         //log.trace(kModControl, "Set parent room");
         Node* curNode = currentNode();

--- a/src/Room.cpp
+++ b/src/Room.cpp
@@ -20,6 +20,7 @@
 #include "Audio.h"
 #include "Node.h"
 #include "Room.h"
+#include "Spot.h"
 
 namespace dagon {
 
@@ -108,6 +109,33 @@ int Room::unpersistEvent() {
 
 size_t Room::numNodes() {
   return _arrayOfNodes.size();
+}
+
+std::set<Audio*> Room::allAudios() {
+  std::set<Audio*> roomAudios;
+  roomAudios.insert(_arrayOfAudios.begin(), _arrayOfAudios.end());
+
+  if (hasNodes()) {
+    beginIteratingNodes();
+
+    do {
+      Node *curNode = iterator();
+
+      if (curNode->hasSpots()) {
+        curNode->beginIteratingSpots();
+
+        do {
+          Spot *curSpot = curNode->currentSpot();
+
+          if (curSpot->hasAudio()) {
+            roomAudios.insert(curSpot->audio());
+          }
+        } while (curNode->iterateSpots());
+      }
+    } while (iterateNodes());
+  }
+
+  return roomAudios;
 }
 
 Node* Room::iterator() {

--- a/src/Room.h
+++ b/src/Room.h
@@ -18,6 +18,7 @@
 // Headers
 ////////////////////////////////////////////////////////////
 
+#include <set>
 #include <vector>
 #include "Configurable.h"
 
@@ -56,7 +57,8 @@ class Room : public Object {
   int persistEvent();
   int unpersistEvent();
   size_t numNodes();
-  
+  std::set<Audio*> allAudios();
+
   // Sets
   void setDefaultFootstep(Audio* theFootstep);
   void setEffects(const SettingCollection& theEffects);


### PR DESCRIPTION
This PR changes the mechanism for releasing audio resources. Now audio resources will not be released once the engine determines they are no longer needed, but will release **all** audio resources contained within a room when you switch rooms - except for those resources that will be used in the new room (as agreed upon in #149)

This change probably makes some code unnecessary but I am not sure which atm, so I suggest removing that in follow-ups. We will probably also want to enforce this change of policy for other room resources as well (videos for instance), but likewise I propose that to be done in follow-ups.