### PR TITLE
Never turn more than 180 degrees as a result of the lookAt command

### DIFF
--- a/src/CameraManager.cpp
+++ b/src/CameraManager.cpp
@@ -251,7 +251,17 @@ void CameraManager::setTargetAngle(float horizontal, float vertical, bool fovAdj
     }
     
     // FIXME: This division is related to the amount of configured inertia. Not right.
-    _targetHError = fabs(_angleHTarget - _angleH) / 10.0;
+    if (fabs(_angleHTarget - _angleH) > M_PI) {
+      if (_angleH > _angleHTarget) {
+        _targetHError = fabs(_angleHTarget - _angleH + 2 * M_PI) / 10.0;
+      }
+      else {
+        _targetHError = fabs(_angleHTarget - _angleH - 2 * M_PI) / 10.0;
+      }
+    }
+    else {
+      _targetHError = fabs(_angleHTarget - _angleH) / 10.0;
+    }
     
     if (_targetHError < 0.02)
       _targetHError = 0.02;
@@ -481,8 +491,11 @@ void CameraManager::pan(int xPosition, int yPosition) {
 
 void CameraManager::panToTargetAngle() {
   if (!_isLocked) {
-    if (_angleH < (_angleHTarget - _targetHError) || _angleH > (_angleHTarget + _targetHError)) {
+    if (fabs(_angleHTarget - _angleH) > _targetHError) {
       _deltaX = static_cast<int>((_angleHTarget - _angleH) * 360);
+      if (fabs(_angleHTarget - _angleH) > M_PI) {
+        _deltaX *= -1;
+      }
       _speedH = static_cast<float>(fabs((float)_deltaX) / ((float)_speedFactor) * 4);
     }
     else {


### PR DESCRIPTION
Perhaps not the prettiest way to fix #121 , but I find the camera code to be rather difficult to follow so I went with it anyway.

The `lookAt` command would occasionally turn right even though it would have been shorter to turn left (or vice versa) and it seems to have been caused by `_deltaX = static_cast<int>((_angleHTarget - _angleH) * 360);`
Consider `_angleHTarget = (3/2) * PI` and `_angleH = 0`. In this example `_deltaX` will be positive. That means the camera will turn 270° to the right instead of 90° to the left.
In general this means that when there is more than 180° between the target direction and the current direction, the camera will turn in the "wrong" direction.