### PR TITLE
Add more hotkeys and allow overriding escape & space

### DIFF
--- a/src/Control.cpp
+++ b/src/Control.cpp
@@ -251,11 +251,16 @@ void Control::processFunctionKey(int aKey) {
 }
 
 void Control::processKey(int aKey, int eventFlags) {
+  int idx = 0;
+
   switch (eventFlags) {
     case EventKeyDown:
       switch (aKey) {
         case kKeyEscape:
-          if (_state->current() == StateSplash) {
+          if (_hotkeyData[18].enabled) { // 18 is escape's index. Is it assigned as a hotkey?
+            script.processCommand(_hotkeyData[18].line);
+          }
+          else if (_state->current() == StateSplash) {
             _cancelSplash = true;
           }
           else {
@@ -278,7 +283,10 @@ void Control::processKey(int aKey, int eventFlags) {
           _console->toggle();
           break;
         case kKeySpace:
-          if (_console->isHidden())
+          if (_hotkeyData[19].enabled) { // 19 is space's index. Is it assigned as a hotkey?
+            script.processCommand(_hotkeyData[19].line);
+          }
+          else if (_console->isHidden())
             config.showHelpers = !config.showHelpers;
           break;
         case 'w':
@@ -305,6 +313,18 @@ void Control::processKey(int aKey, int eventFlags) {
             cameraManager.pan(config.displayWidth, kCurrent);
           }
           break;
+
+        case kKeyI: idx = 13; break;
+        case kKeyJ: idx = 14; break;
+        case kKeyL: idx = 15; break;
+        case kKeyO: idx = 16; break;
+        case kKeyP: idx = 17; break;
+      }
+
+      if (idx != 0) {
+        if (_hotkeyData[idx].enabled) {
+          script.processCommand(_hotkeyData[idx].line);
+        }
       }
       
       // Process these keys only when the console is visible
@@ -520,6 +540,13 @@ void Control::registerHotkey(int aKey, const char* luaCommandToExecute) {
     case kKeyF10: idx = 10; break;
     case kKeyF11: idx = 11; break;
     case kKeyF12: idx = 12; break;
+    case kKeyI: idx = 13; break;
+    case kKeyJ: idx = 14; break;
+    case kKeyL: idx = 15; break;
+    case kKeyO: idx = 16; break;
+    case kKeyP: idx = 17; break;
+    case kKeyEscape: idx = 18; break;
+    case kKeySpace: idx = 19; break;
   }
   
   if (idx) {

--- a/src/Control.cpp
+++ b/src/Control.cpp
@@ -257,7 +257,7 @@ void Control::processKey(int aKey, int eventFlags) {
     case EventKeyDown:
       switch (aKey) {
         case kKeyEscape:
-          if (_hotkeyData[18].enabled) { // 18 is escape's index. Is it assigned as a hotkey?
+          if (_hotkeyData[18].enabled && _console->isHidden()) { // 18 is escape's index. Is it assigned as a hotkey?
             script.processCommand(_hotkeyData[18].line);
           }
           else if (_state->current() == StateSplash) {
@@ -283,7 +283,7 @@ void Control::processKey(int aKey, int eventFlags) {
           _console->toggle();
           break;
         case kKeySpace:
-          if (_hotkeyData[19].enabled) { // 19 is space's index. Is it assigned as a hotkey?
+          if (_hotkeyData[19].enabled && _console->isHidden()) { // 19 is space's index. Is it assigned as a hotkey?
             script.processCommand(_hotkeyData[19].line);
           }
           else if (_console->isHidden())
@@ -321,7 +321,7 @@ void Control::processKey(int aKey, int eventFlags) {
         case kKeyP: idx = 17; break;
       }
 
-      if (idx != 0) {
+      if (idx != 0 && _console->isHidden()) {
         if (_hotkeyData[idx].enabled) {
           script.processCommand(_hotkeyData[idx].line);
         }

--- a/src/Control.h
+++ b/src/Control.h
@@ -31,7 +31,7 @@ namespace dagon {
 // Definitions
 ////////////////////////////////////////////////////////////
 
-#define kMaxHotKeys 13
+#define kMaxHotKeys 20
 
 class AudioManager;
 class CameraManager;

--- a/src/Platform.h
+++ b/src/Platform.h
@@ -104,7 +104,12 @@ enum InputKeys {
   kKeyQuote = SDL_SCANCODE_GRAVE,
   kKeyTab = SDLK_TAB,
   kKeyEnter = SDLK_RETURN,
-  kKeySpace = SDLK_SPACE
+  kKeySpace = SDLK_SPACE,
+  kKeyI = SDLK_i,
+  kKeyJ = SDLK_j,
+  kKeyL = SDLK_l,
+  kKeyO = SDLK_o,
+  kKeyP = SDLK_p
 };
   
 }

--- a/src/Script.cpp
+++ b/src/Script.cpp
@@ -1002,6 +1002,13 @@ void Script::_registerEnums() {
   DGLuaEnum(_L, F10, kKeyF10);
   DGLuaEnum(_L, F11, kKeyF11);
   DGLuaEnum(_L, F12, kKeyF12);
+  DGLuaEnum(_L, KEY_i, kKeyI);
+  DGLuaEnum(_L, KEY_j, kKeyJ);
+  DGLuaEnum(_L, KEY_l, kKeyL);
+  DGLuaEnum(_L, KEY_o, kKeyO);
+  DGLuaEnum(_L, KEY_p, kKeyP);
+  DGLuaEnum(_L, ESC, kKeyEscape);
+  DGLuaEnum(_L, SPACE, kKeySpace);
   
   DGLuaEnum(_L, SLOW, kFadeSlow);
   DGLuaEnum(_L, SLOWEST, kFadeSlowest);


### PR DESCRIPTION
This change allows developers to assign `i`, `j`, `l`, `o`, `p`, as hotkeys through the `KEY_i`, `KEY_j`, `KEY_l`, `KEY_o`, `KEY_p` constants respectively.

One can also override the default behaviour of the escape and space keys by assigning `ESC` and `SPACE` like you would any other hotkeys.