### PR TITLE
Stop timers started through script when loading a saved game

### DIFF
--- a/src/Script.cpp
+++ b/src/Script.cpp
@@ -838,6 +838,14 @@ int Script::_globalUnpersist(lua_State *L) {
 
   loader.toggleAudio();
 
+  // Stop running timers.
+  for (auto timer : TimerManager::instance().timers()) {
+    if (timer.type == DGTimerNormal) {
+      // We only touch timers made by the game developer.
+      TimerManager::instance().disable(timer.handle);
+    }
+  }
+
   if (!loader.readTimers()) {
     Log::instance().error(kModScript, "Error reading timers! %s", SDL_GetError());
     lua_pushboolean(L, false);


### PR DESCRIPTION
It was brought to my attention that Seclusion was faced with undesired behaviour when loading while a timer was running: The timer kept running after the load.

This was intentionally left at such because I don't quite trust the timer persistence system yet. It remains one of the most untested parts after all, so I opted to let timers run in case a timer that was supposed to have been saved couldn't be brought back.

But now that decision is causing pain I decided to "fix" it. Keep in mind that this means that if you have any timers you find aren't persisted correctly, you might have to use the [persistence system callbacks](https://github.com/Senscape/Dagon/wiki/Persistence#callbacks) to manually bring them back after loading.