### PR TITLE
Default cursor for Overlays

### DIFF
--- a/src/Interface.cpp
+++ b/src/Interface.cpp
@@ -191,6 +191,9 @@ bool Interface::scanOverlays() {
                 
                 return true;
               }
+              else {
+                cursorManager.setCursor((*itOverlay)->defaultCursor());
+              }
             }
           } while ((*itOverlay)->iterateButtons());
         }

--- a/src/Overlay.cpp
+++ b/src/Overlay.cpp
@@ -18,6 +18,7 @@
 #include <cassert>
 
 #include "Button.h"
+#include "Defines.h"
 #include "Image.h"
 #include "Overlay.h"
 
@@ -32,6 +33,7 @@ Overlay::Overlay() {
   _position.y = 0;
   _isIteratingBackwards = false;
   _isLocked = false;
+  _defaultCursor = kCursorNormal;
   this->disable(); // Overlays are disabled by default
   this->setType(kObjectOverlay);
 }
@@ -75,6 +77,10 @@ bool Overlay::isLocked() {
   return _isLocked;
 }
 
+int Overlay::defaultCursor() const {
+  return _defaultCursor;
+}
+
 ////////////////////////////////////////////////////////////
 // Implementation - Sets
 ////////////////////////////////////////////////////////////
@@ -90,6 +96,12 @@ void Overlay::setPosition(int x, int y) {
   // Store the new position
   _position.x = x;
   _position.y = y;
+}
+
+void Overlay::setDefaultCursor(int cursor) {
+  if (cursor >= kCursorNormal && kCursorCustom >= cursor) {
+    _defaultCursor = cursor;
+  }
 }
 
 ////////////////////////////////////////////////////////////

--- a/src/Overlay.h
+++ b/src/Overlay.h
@@ -49,9 +49,11 @@ class Overlay : public Object {
   Button* currentButton();
   Image* currentImage();
   bool isLocked();
+  int defaultCursor() const;
   
   // Sets
   void setPosition(int x, int y);
+  void setDefaultCursor(int cursor);
   
   // State changes
   Button* addButton(Button* aButton);
@@ -74,6 +76,8 @@ class Overlay : public Object {
   bool _isLocked;
   bool _isIteratingBackwards;
   Point _position;
+
+  int _defaultCursor;
   
   Overlay(const Overlay&);
   void operator=(const Overlay&);

--- a/src/OverlayProxy.h
+++ b/src/OverlayProxy.h
@@ -122,6 +122,11 @@ public:
     
     return 0;
   }
+
+  int setDefaultCursor(lua_State *L) {
+    o->setDefaultCursor(static_cast<int>(luaL_checknumber(L, 1)));
+    return 0;
+  }
   
   Overlay* ptr() { return o; }
   
@@ -145,6 +150,7 @@ Luna<OverlayProxy>::RegType OverlayProxy::methods[] = {
   method(OverlayProxy, move),
   method(OverlayProxy, position),
   method(OverlayProxy, setPosition),
+  method(OverlayProxy, setDefaultCursor),
   {0,0}
 };
   


### PR DESCRIPTION
This defines default cursor for an Overlay as "the cursor to be displayed when no Buttons are hovered". It's defined this way because currently Buttons are the only elements that change the cursor in an Overlay.
The default cursor can be set from Lua by calling the `setDefaultCursor` function on an Overlay. The only parameter is the cursor to use, and any parameter value that is valid for `setCursor` on Button etc. is also valid for `setDefaultCursor`.

It was requested for Seclusion: Islesbury because the current behaviour means that if you hover a e.g. an inventory item (implemented as a Button which changes the cursor), the cursor will stay the same until another Button is hovered, causing the cursor to "linger" when no Button is hovered.