### PR TITLE
Only allow console to be toggled by tab.

### DIFF
--- a/src/Control.cpp
+++ b/src/Control.cpp
@@ -278,7 +278,6 @@ void Control::processKey(int aKey, int eventFlags) {
             }
           }
           break;
-        case kKeyQuote:
         case kKeyTab:
           _console->toggle();
           break;


### PR DESCRIPTION
`kKeyQuote` conflicted with the `5` key, both numpad and otherwise, on mine and Civan's keyboards. As a result it was impossible to type `5` in the console so I just removed the shortcut. I really don't understand why that conflict exists however. `kKeyQuote` equals `SDL_SCANCODE_GRAVE` (53) if that means anything to anyone?