### PR TITLE
Optimize config for VS2015 builds.

### DIFF
--- a/visualc/Dagon.vcxproj
+++ b/visualc/Dagon.vcxproj
@@ -56,12 +56,12 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='debug native|Win32'">
     <ClCompile>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <WarningLevel>Level3</WarningLevel>
+      <WarningLevel>Level4</WarningLevel>
       <PreprocessorDefinitions>_DEBUG;DEBUG;GLEW_STATIC;OV_EXCLUDE_STATIC_CALLBACKS;KTX_OPENGL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>C:\lua-5.1.5\include;..\extlibs\headers;..\extlibs\headers\libfreetype\windows;..\extlibs\headers\libfreetype\windows\freetype;..\extlibs\headers\libsdl2\windows;..\extlibs\headers\dirent;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
       <Optimization>Disabled</Optimization>
-      <AdditionalOptions>-Wall %(AdditionalOptions)</AdditionalOptions>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -77,7 +77,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='release native|Win32'">
     <ClCompile>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <WarningLevel>Level3</WarningLevel>
+      <WarningLevel>Level4</WarningLevel>
       <PreprocessorDefinitions>NDEBUG;GLEW_STATIC;OV_EXCLUDE_STATIC_CALLBACKS;KTX_OPENGL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>..\extlibs\headers;..\extlibs\headers\libfreetype\windows;..\extlibs\headers\libfreetype\windows\freetype;..\extlibs\headers\libsdl2\windows;..\extlibs\headers\dirent;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <Optimization>Full</Optimization>
@@ -85,7 +85,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <MinimalRebuild>false</MinimalRebuild>
       <StringPooling>true</StringPooling>
-      <AdditionalOptions>-Wall %(AdditionalOptions)</AdditionalOptions>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>


### PR DESCRIPTION
Remove -Wall because it will generate around 20k warnings from the msvc implementation of standard libraries. Bump warning level up to 4 instead of 3. Use multiprocessor compilation when available.