### PR TITLE
Transfer assets on room change

### DIFF
--- a/src/Control.h
+++ b/src/Control.h
@@ -104,7 +104,6 @@ class Control {
   
   std::vector<Room*> _arrayOfRooms;
   Room* _currentRoom;
-  Room* _previousRoom;
   
   Console* _console;
   Interface* _interface;

--- a/src/Room.cpp
+++ b/src/Room.cpp
@@ -204,13 +204,18 @@ void Room::claimAsset(Object* obj) {
   }
 }
 
-void Room::releaseAssets() {
+void Room::releaseAssets(Room* newRoom) {
   for (auto audio : _arrayOfAudios) {
     if (!audio->isPlaying()) {
       _claimedAssets.erase(AudioManager::instance().asAsset(audio->filename()));
     }
-    else if (!audio->isFading()) {
+    else {
       audio->fadeOut();
+      if (newRoom) {
+        newRoom->claimAsset(audio);
+      }
+
+      _claimedAssets.erase(AudioManager::instance().asAsset(audio->filename()));
     }
   }
 

--- a/src/Room.h
+++ b/src/Room.h
@@ -78,7 +78,7 @@ class Room : public Object {
   bool switchTo(Node* theNode);
   void claimAssets();
   void claimAsset(Object* obj);
-  void releaseAssets();
+  void releaseAssets(Room* newRoom);
   
  private:
   SettingCollection _theEffects;


### PR DESCRIPTION
When a room switch occurs, we will now transfer audio assets that are not immediately ready to be unloaded (i.e. they need to be faded) to the next room. This might delay unloading until the next room switch, but it is a much more robust way of making sure the fading in between rooms work correctly.