### PR TITLE
Improve code for resolving asset paths

### DIFF
--- a/src/AudioAsset.h
+++ b/src/AudioAsset.h
@@ -15,6 +15,7 @@
 #define DAGON_AUDIO_ASSET_H_
 
 #include "Asset.h"
+#include "Config.h"
 
 #include <fstream>
 
@@ -43,16 +44,29 @@ protected:
   virtual bool _load() {
     std::ifstream file(id(), std::ifstream::binary | std::ifstream::ate);
     if (file.good()) {
-      _dataSize = file.tellg();
-      _data = new char[_dataSize];
+      goto READ_FILE;
+    }
+    else {
+      auto pos = id().find_last_of('/');
+      if (pos != std::string::npos) {
+        file = std::ifstream(Config::instance().defAssetPath(id().substr(pos), kObjectAudio),
+                             std::ifstream::binary | std::ifstream::ate);
+        if (file.good()) {
+          goto READ_FILE;
+        }
+      }
 
-      file.seekg(file.beg);
-      file.read(_data, _dataSize);
-      file.close();
-      return true;
+      return false;
     }
 
-    return false;
+  READ_FILE:
+    _dataSize = file.tellg();
+    _data = new char[_dataSize];
+
+    file.seekg(file.beg);
+    file.read(_data, _dataSize);
+    file.close();
+    return true;
   }
 };
 

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -100,7 +100,6 @@ std::string Config::path(int ofType, const std::string &forFile,
     case kPathResources: {
       fullPath = _resPath;
       if (autopaths) {
-        // This is a temporary hack until the Resources manager is implemented
         if (Script::instance().isExecutingModule()) {
           std::string roomPath = Script::instance().module();
           fullPath += "rooms/";
@@ -108,67 +107,13 @@ std::string Config::path(int ofType, const std::string &forFile,
           fullPath += "/";
         }
         else {
-          switch (andObject) {
-            case kObjectAudio: {
-              fullPath += kDefAudioPath;
-              break;
-            }
-            case kObjectCursor: {
-              fullPath += kDefCursorPath;
-              break;
-            }
-            case kObjectFont: {
-              fullPath += kDefFontPath;
-              break;
-            }
-            case kObjectImage: {
-              fullPath += kDefImagePath;
-              break;
-            }
-            case kObjectNode: {
-              fullPath += kDefNodePath;
-              break;
-            }
-            case kObjectVideo: {
-              fullPath += kDefVideoPath;
-              break;
-            }
-            default: {
-              assert(false);
-            }
-          }
+          fullPath = defAssetPath(forFile, andObject);
+          return fullPath;
         }
       }
       else {
-        switch (andObject) {
-        case kObjectAudio: {
-          fullPath += kDefAudioPath;
-          break;
-        }
-        case kObjectCursor: {
-          fullPath += kDefCursorPath;
-          break;
-        }
-        case kObjectFont: {
-          fullPath += kDefFontPath;
-          break;
-        }
-        case kObjectImage: {
-          fullPath += kDefImagePath;
-          break;
-        }
-        case kObjectNode: {
-          fullPath += kDefNodePath;
-          break;
-        }
-        case kObjectVideo: {
-          fullPath += kDefVideoPath;
-          break;
-        }
-        default: {
-          assert(false);
-        }
-        }
+        fullPath = defAssetPath(forFile, andObject);
+        return fullPath;
       }
       break;
     }
@@ -185,6 +130,43 @@ std::string Config::path(int ofType, const std::string &forFile,
   
   fullPath += forFile;
   
+  return fullPath;
+}
+
+std::string Config::defAssetPath(const std::string &forFile, int andObject) {
+  std::string fullPath = _resPath;
+
+  switch (andObject) {
+  case kObjectAudio: {
+    fullPath += kDefAudioPath;
+    break;
+  }
+  case kObjectCursor: {
+    fullPath += kDefCursorPath;
+    break;
+  }
+  case kObjectFont: {
+    fullPath += kDefFontPath;
+    break;
+  }
+  case kObjectImage: {
+    fullPath += kDefImagePath;
+    break;
+  }
+  case kObjectNode: {
+    fullPath += kDefNodePath;
+    break;
+  }
+  case kObjectVideo: {
+    fullPath += kDefVideoPath;
+    break;
+  }
+  default: {
+    assert(false);
+  }
+  }
+
+  fullPath += forFile;
   return fullPath;
 }
 

--- a/src/Config.h
+++ b/src/Config.h
@@ -112,6 +112,7 @@ class Config {
   double framesPerSecond();
   float globalSpeed();
   std::string path(int ofType, const std::string &forFile, int andObject);
+  std::string defAssetPath(const std::string &forFile, int andObject);
   std::string script();
   std::string texExtension();
   
@@ -119,9 +120,6 @@ class Config {
   void setPath(int forType, std::string thePath);
   void setScript(std::string name);
   void setTexExtension(std::string ext);
-  
-  // TODO: Provide members to save/load configurations
-  // (also used by system to save them in the user's folder)
   
  private:
   std::string _appPath;


### PR DESCRIPTION
In e21d704 I did a rather lazy fix for a bug where the path to an audio asset could be resolved to different paths during runtime, depending on the circumstances the path was generated under. This atones for that by falling back to looking for the asset in the general folder, it if couldn't be found in a room specific folder.