### PR TITLE
Fix deadlocks in audio code

### DIFF
--- a/src/Audio.h
+++ b/src/Audio.h
@@ -36,7 +36,7 @@
 #include <vorbis/vorbisfile.h>
 #include <SDL2/SDL_mutex.h>
 
-#include "Asset.h"
+#include "AudioAsset.h"
 #include "Defines.h"
 #include "Object.h"
 #include "Geometry.h"
@@ -112,6 +112,7 @@ private:
   Audio* _matchedAudio;
   SDL_mutex* _mutex;
 
+  std::shared_ptr<AudioAsset> _asset;
   std::string _audioName;
   AssetID_t _filename;
   size_t _dataRead;

--- a/src/AudioManager.cpp
+++ b/src/AudioManager.cpp
@@ -155,6 +155,7 @@ void AudioManager::init() {
 void AudioManager::registerAudio(Audio* target) {
   if (SDL_LockMutex(_mutex) == 0) {
     _activeAudios.insert(target);
+    target->_asset = asAsset(target->filename());
     SDL_UnlockMutex(_mutex);
   }
   else {
@@ -244,6 +245,7 @@ bool AudioManager::_update() {
 
     for (auto it = _activeAudios.begin(); it != _activeAudios.end();) {
       if ((*it)->state() == kAudioStopped) {
+        (*it)->_asset.reset();
         (*it)->_unload();
 
         if ((*it)->isType(kObjectInternalAudio)) {

--- a/src/AudioProxy.h
+++ b/src/AudioProxy.h
@@ -84,6 +84,7 @@ public:
   
   // Play the audio
   int play(lua_State *L) {
+    AudioManager::instance().registerAudio(a);
     a->play();
     return 0;
   }

--- a/src/Control.cpp
+++ b/src/Control.cpp
@@ -687,6 +687,7 @@ void Control::switchTo(Object* theTarget) {
           }
 
           if (audio->doesAutoplay()) {
+            audioManager.registerAudio(audio);
             audio->play();
           }
         }
@@ -792,6 +793,7 @@ void Control::switchTo(Object* theTarget) {
 
         for (Audio *audio : audiosToPlay) {
           if (!audio->isPlaying()) {
+            audioManager.registerAudio(audio);
             audio->fadeIn();
             audio->play();
           }
@@ -969,6 +971,7 @@ void Control::walkTo(Object* theTarget) {
   // Finally, check if must play a single footstep
   if (current->hasFootstep()) {
     assetRoom()->claimAsset(current->footstep());
+    audioManager.registerAudio(current->footstep());
     current->footstep()->play();
 
     Audio* footstep = new InternalAudio(true);
@@ -977,6 +980,7 @@ void Control::walkTo(Object* theTarget) {
   }
   else if (_currentRoom->hasDefaultFootstep()) {
     assetRoom()->claimAsset(_currentRoom->defaultFootstep());
+    audioManager.registerAudio(_currentRoom->defaultFootstep());
     _currentRoom->defaultFootstep()->play();
 
     Audio* footstep = new InternalAudio(true);

--- a/src/Deserializer.cpp
+++ b/src/Deserializer.cpp
@@ -17,6 +17,7 @@
 
 #include "Deserializer.h"
 #include "Audio.h"
+#include "AudioManager.h"
 #include "CameraManager.h"
 #include "Config.h"
 #include "Control.h"
@@ -283,8 +284,10 @@ void Deserializer::toggleAudio() {
       break;
     }
     case kAudioPlaying: {
-      if (!audio->isPlaying())
+      if (!audio->isPlaying()) {
+        AudioManager::instance().registerAudio(audio);
         audio->play();
+      }
       break;
     }
     case kAudioPaused: {

--- a/src/FeedManager.cpp
+++ b/src/FeedManager.cpp
@@ -150,6 +150,7 @@ void FeedManager::showAndPlay(const char* text, const char* audio) {
       Control::instance().assetRoom()->claimAsset(_feedAudio);
     }
 
+    audioManager.registerAudio(_feedAudio);
     _feedAudio->play();
   }
 }

--- a/src/Script.cpp
+++ b/src/Script.cpp
@@ -493,6 +493,7 @@ int Script::_globalPlay(lua_State *L) {
     audio->setVarying(lua_toboolean(L, 2));
   }
   
+  AudioManager::instance().registerAudio(audio);
   audio->play();
   return 0;
 }

--- a/src/Spot.cpp
+++ b/src/Spot.cpp
@@ -21,6 +21,7 @@
 #include <sstream>
 
 #include "Audio.h"
+#include "AudioManager.h"
 #include "Group.h"
 #include "Spot.h"
 #include "Texture.h"
@@ -216,8 +217,10 @@ void Spot::play() {
   _isPlaying = true;
   
   // FIXME: Should start playing only if in the current room
-  if (_hasAudio)
+  if (_hasAudio) {
+    AudioManager::instance().registerAudio(_attachedAudio);
     _attachedAudio->play();
+  }
   
   if (_hasVideo && _attachedVideo->isLoaded())
     _attachedVideo->play();


### PR DESCRIPTION
All sorts of deadlocks can be imagined from the audio code I merged in #161. At least one would sometimes show itself in Seclusion. At the heart of the problem is how the AudioManager locks both itself and Audio objects, and Audio objects also lock the AudioManager. This allows for the AudioManager to hold a lock on an Audio object in one thread, and for the audio object to hold a lock on the AudioManager in another thread. The fix then, is to disentangle Audio objects from the AudioManager in the sense that Audio objects won't lock the AudioManager, but the AudioManager can still lock the Audio objects it manages.