### PR TITLE
Don't force control mode when leaving slides

### DIFF
--- a/src/Control.cpp
+++ b/src/Control.cpp
@@ -740,10 +740,6 @@ void Control::switchTo(Object* theTarget) {
             return;
           }
           
-          // This was commented out due to a game specific issue.
-          // "Seclusion: Islesbury" uses a custom behaviour for leaving Slides.
-          // As a result this change was an easy fix to the problem of the game
-          // being unable to use direct control mode after leaving a Slide.
           _directControlActive = false;
           
           cameraManager.lock();

--- a/src/Control.cpp
+++ b/src/Control.cpp
@@ -83,6 +83,11 @@ videoManager(VideoManager::instance())
   // This is used to randomize the color of certain spots,
   // should be called once during initialization.
   srand((unsigned)time(0));
+
+  // In case the game is loaded in a slide, this should have a sensible default value.
+  // Optionally this can be added to the saved state to preserve it between sessions.
+  // But for now, this simpler solution is adequate.
+  _prevControlMode = kControlFree;
   
   // For precaution, we set all these to false
   
@@ -720,6 +725,12 @@ void Control::switchTo(Object* theTarget) {
       case kObjectSlide:
         //log.trace(kModControl, "Switching to slide...");
         if (_currentRoom) {
+          if (currentNode() && !currentNode()->isSlide()) {
+            // We are switching to a slide from something that is not a slide.
+            // The control mode should be saved.
+            _prevControlMode = config.controlMode;
+          }
+
           Node* node = (Node*)theTarget;
           //log.trace(kModControl, "Set previous node");
           node->setPreviousNode(this->currentNode());
@@ -733,7 +744,7 @@ void Control::switchTo(Object* theTarget) {
           // "Seclusion: Islesbury" uses a custom behaviour for leaving Slides.
           // As a result this change was an easy fix to the problem of the game
           // being unable to use direct control mode after leaving a Slide.
-          // _directControlActive = false;
+          _directControlActive = false;
           
           cameraManager.lock();
         }
@@ -874,6 +885,7 @@ void Control::switchTo(Object* theTarget) {
       
       if (!previous->isSlide()) {
         //log.trace(kModControl, "Unlock camera and return to direct control");
+        config.controlMode = _prevControlMode;
         cameraManager.unlock();
         if (config.controlMode == kControlFixed)
           // FIXME: Forced, but it should return to the previous mode

--- a/src/Control.h
+++ b/src/Control.h
@@ -122,6 +122,7 @@ class Control {
   bool _isShuttingDown;
   int _shutdownTimer;
   int _sleepTimer;
+  int _prevControlMode;
   
   void _processAction();
   void _updateView(int state, bool inBackground);


### PR DESCRIPTION
Currently we force the control mode to "fixed" when the player returns from a slide. This change stores the current control mode in a `_prevControlMode` variable when the player goes from a node to a slide. When the player returns from a slide, we restore the control mode. `_prevControlMode` is set to "free" by default, in case the player loads the game into a slide from a savegame. If it turns out to be necessary, we can update the persistence code to include the `_prevControlMode` variable in the save files.
Actually the code that forces the control mode to "fixed" is still in place, this change just overrides that behaviour for slides.