### PR TITLE
Update neutral zones after changing control mode

### DIFF
--- a/src/Control.cpp
+++ b/src/Control.cpp
@@ -882,6 +882,7 @@ void Control::switchTo(Object* theTarget) {
       if (!previous->isSlide()) {
         //log.trace(kModControl, "Unlock camera and return to direct control");
         config.controlMode = _prevControlMode;
+        cameraManager.setViewport(config.displayWidth, config.displayHeight);
         cameraManager.unlock();
         if (config.controlMode == kControlFixed)
           // FIXME: Forced, but it should return to the previous mode


### PR DESCRIPTION
After changing control mode (depending on from which and to which you switch), the neutral zones need to be updated by a call to `CameraManager::setViewport`. Ideally a function like
```c++
void setControlMode(int mode) {
    config.controlMode = mode;
    cameraManager.setViewport(config.displayWidth, config.displayHeight);
}
```
Should have been defined to make sure we don't forget this step, but there's not much point when the code is already full of "raw" access to `config.controlMode`.