### PR TITLE
Defer loading Image textures

### DIFF
--- a/src/Image.cpp
+++ b/src/Image.cpp
@@ -37,11 +37,12 @@ Image::Image(const std::string &fromFileName) :
 config(Config::instance())
 {
   this->setTexture(fromFileName);
-  if (_attachedTexture->isLoaded()) {
+  if (_attachedTexture->isBitmapLoaded()) {
     _rect.origin = ZeroPoint;
     _rect.size = MakeSize(_attachedTexture->width(),
                           _attachedTexture->height());
     _calculateCoordinates();
+    _attachedTexture->unloadBitmap();
   }
   this->setType(kObjectImage);
 }
@@ -71,6 +72,7 @@ Size Image::size() {
 }
 
 Texture* Image::texture() {
+  _attachedTexture->load();
   return _attachedTexture;
 }
 
@@ -97,7 +99,7 @@ void Image::setTexture(const std::string &fromFileName) {
   _attachedTexture = new Texture;
   _attachedTexture->setResource(config.path(kPathResources, fromFileName,
                                             kObjectImage).c_str());
-  _attachedTexture->load();
+  _attachedTexture->loadBitmap();
   _hasTexture = true;
 }
 

--- a/src/Image.cpp
+++ b/src/Image.cpp
@@ -24,7 +24,7 @@
 
 namespace dagon {
 
-static const PNG_HEADER[8] = {137, 80, 78, 71, 13, 10, 26, 10};
+static const unsigned char PNG_HEADER[8] = {137, 80, 78, 71, 13, 10, 26, 10};
 
 ////////////////////////////////////////////////////////////
 // Implementation - Constructor
@@ -117,10 +117,10 @@ void Image::setTexture(const std::string &fromFileName) {
       bitmapFile.seekg(16); // Skip header (8 bytes) and IHDR chunk header (8 bytes).
 
       bitmapFile.read(buf, 4); // Read width (big endian integer).
-      int width = buf[0] << 24 + buf[1] << 16 + buf[2] << 8 + buf[3];
+      int width = (buf[0] << 24) + (buf[1] << 16) + (buf[2] << 8) + buf[3];
 
       bitmapFile.read(buf, 4); // Read height (big endian integer).
-      int height = buf[0] << 24 + buf[1] << 16 + buf[2] << 8 + buf[3];
+      int height = (buf[0] << 24) + (buf[1] << 16) + (buf[2] << 8) + buf[3];
 
       if (width <= 0 || height <= 0) { // In this case we should let STBI handle this file.
         _attachedTexture->loadBitmap();

--- a/src/Image.cpp
+++ b/src/Image.cpp
@@ -19,7 +19,12 @@
 #include "Image.h"
 #include "Texture.h"
 
+#include <cstring>
+#include <fstream>
+
 namespace dagon {
+
+static const PNG_HEADER[8] = {137, 80, 78, 71, 13, 10, 26, 10};
 
 ////////////////////////////////////////////////////////////
 // Implementation - Constructor
@@ -95,11 +100,42 @@ void Image::setTexture(const std::string &fromFileName) {
   // to avoid repeating resources. Eventually, this would be done via the
   // resource manager.
   // FIXME: These textures are immediately loaded which isn't very efficient.
-  
+
   _attachedTexture = new Texture;
   _attachedTexture->setResource(config.path(kPathResources, fromFileName,
                                             kObjectImage).c_str());
-  _attachedTexture->loadBitmap();
+  std::ifstream bitmapFile(_attachedTexture->resource(), std::ios::in |
+                                                         std::ios::binary);
+  if (!bitmapFile.good()) {
+    _attachedTexture->loadBitmap();
+  }
+  else {
+    char header[8];
+    bitmapFile.read(header, 8);
+    if (std::memcmp(header, PNG_HEADER, 8) == 0) {
+      char buf[4]; // Width and height are stored as 32 bit words.
+      bitmapFile.seekg(16); // Skip header (8 bytes) and IHDR chunk header (8 bytes).
+
+      bitmapFile.read(buf, 4); // Read width (big endian integer).
+      int width = buf[0] << 24 + buf[1] << 16 + buf[2] << 8 + buf[3];
+
+      bitmapFile.read(buf, 4); // Read height (big endian integer).
+      int height = buf[0] << 24 + buf[1] << 16 + buf[2] << 8 + buf[3];
+
+      if (width <= 0 || height <= 0) { // In this case we should let STBI handle this file.
+        _attachedTexture->loadBitmap();
+      }
+      else {
+        _rect.origin = ZeroPoint;
+        _rect.size = MakeSize(width, height);
+        _calculateCoordinates();
+      }
+    }
+    else {
+      _attachedTexture->loadBitmap();
+    }
+  }
+
   _hasTexture = true;
 }
 

--- a/src/Texture.cpp
+++ b/src/Texture.cpp
@@ -15,6 +15,7 @@
 // Headers
 ////////////////////////////////////////////////////////////
 
+#include <string.h>
 #include <fstream>
 //#include <ktx.h>
 
@@ -113,6 +114,10 @@ bool Texture::hasResource() {
 
 bool Texture::isLoaded() {
   return _isLoaded;
+}
+
+bool Texture::isBitmapLoaded() {
+  return _isBitmapLoaded;
 }
 
 ////////////////////////////////////////////////////////////
@@ -380,6 +385,13 @@ void Texture::loadBitmap() {
     _height = y;
     _depth = comp;
     _isBitmapLoaded = true;
+  }
+}
+
+void Texture::unloadBitmap() {
+  if (_isBitmapLoaded) {
+    free(_bitmap);
+    _isBitmapLoaded = false;
   }
 }
 

--- a/src/Texture.h
+++ b/src/Texture.h
@@ -65,6 +65,7 @@ class Texture : public Object {
   // Checks
   bool hasResource();
   bool isLoaded();
+  bool isBitmapLoaded();
   
   // Gets
   int depth();
@@ -84,6 +85,7 @@ class Texture : public Object {
   void clear();
   void load();
   void loadBitmap(); // Temporary to test preloader
+  void unloadBitmap();
   
   // Textures loaded from memory are not managed
   void loadFromMemory(const unsigned char* dataToLoad, long size);


### PR DESCRIPTION
Some games use Image objects extensively. Examples include inventory items and journal entries. Hence it is quite inefficient to load the texture backing the Image and uploading it to the GPU, as soon as the Image is created. With this change we defer that work until the Image is first shown.
In order to preserve semantics (e.g. being able to query an Image for its size as soon as it's created), the size needs to be available immediately after creation. This is implemented by loading the bitmap and reading its size and then immediately unloading it. Unfortunately this means we load and unload every bitmap twice (obviously not time efficient). I'd be more than happy to implement a suggestion that give us the size of the bitmap without loading the entire thing.