### PR TITLE
Font.cpp: silence g++ sign-compare warning

### DIFF
--- a/src/Font.cpp
+++ b/src/Font.cpp
@@ -196,13 +196,13 @@ void Font::_loadFont(FT_Face &face) {
     FT_BitmapGlyph bitmapGlyph = (FT_BitmapGlyph)glyph;
     FT_Bitmap bitmap = bitmapGlyph->bitmap;
     
-    int width = _next(bitmap.width);
-    int height = _next(bitmap.rows);
+    uint width = _next(bitmap.width);
+    uint height = _next(bitmap.rows);
     GLubyte* expandedData;
     expandedData = new GLubyte[2 * width * height];
     
-    for (int j = 0; j < height; j++) {
-      for (int i = 0; i < width; i++) {
+    for (uint j = 0; j < height; j++) {
+      for (uint i = 0; i < width; i++) {
         expandedData[2 * (i + j * width)] =
         expandedData[2 * (i + j * width) + 1] =
         (i >= bitmap.width || j >= bitmap.rows) ?


### PR DESCRIPTION
```../src/Font.cpp: In member function ‘void dagon::Font::_loadFont(FT_FaceRec_*&)’:
../src/Font.cpp:204:23: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
     for (int j = 0; j < height; j++) {
                       ^
../src/Font.cpp:205:25: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
       for (int i = 0; i < width; i++) {
                         ^
../src/Font.cpp:208:12: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
         (i >= bitmap.width || j >= bitmap.rows) ?
            ^
../src/Font.cpp:208:33: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
         (i >= bitmap.width || j >= bitmap.rows) ?
                                 ^```