### PR TITLE
Fix fixed mode camera speed

### DIFF
--- a/src/CameraManager.cpp
+++ b/src/CameraManager.cpp
@@ -70,18 +70,18 @@ int CameraManager::cursorWhenPanning() {
   if (_motionLeft > 0.0f) {
     if (_motionUp > 0.0f) return kCursorDownLeft;
     else if (_motionDown > 0.0f) return kCursorUpLeft;
-    
+
     return kCursorLeft;
   }
   else if (_motionRight > 0.0f) {
     if (_motionUp > 0.0f) return kCursorDownRight;
     else if (_motionDown > 0.0f) return kCursorUpRight;
-    
+
     return kCursorRight;
   }
   else if (_motionUp > 0.0f) return kCursorDown;
   else if (_motionDown > 0.0f) return kCursorUp;
-  
+
   if (config.controlMode == kControlDrag)
     return kCursorDrag;
   else
@@ -119,7 +119,7 @@ int CameraManager::neutralZone() {
     case kControlFree:
       return _freeNeutralZone;
   }
-  
+
   return 0;
 }
 
@@ -134,7 +134,7 @@ float* CameraManager::position() {
 int CameraManager::speedFactor() {
   return _speedFactor / 10000;
 }
-  
+
 int CameraManager::horizontalLimit() {
   return _toDegrees(_angleHLimit, M_PI * 2);
 }
@@ -163,7 +163,7 @@ void CameraManager::setAngleVertical(float vertical) {
 
 void CameraManager::setBreathe(bool enabled) {
   _canBreathe = true;
-  
+
   if (enabled) {
     _bob.state = DGCamBreathing;
   }
@@ -194,20 +194,20 @@ void CameraManager::setNeutralZone(int zone) {
     case kControlDrag:
       _dragNeutralZone = zone;
       break;
-      
+
     case kControlFixed:
     case kControlFree:
       _freeNeutralZone = zone;
-      
+
       int percentageX = ((config.displayWidth * zone) / 100) / 2;
       int percentageY = ((config.displayHeight * zone) / 100) / 2;
-      
+
       // Update panning regions with the new neutral zone
       _panRegion = MakeRect((_viewport.width * 0.5) - percentageX,
                             (_viewport.height * 0.5) - percentageY,
                             (_viewport.width * 0.5) + percentageX,
                             (_viewport.height * 0.5) + percentageY);
-      
+
       break;
   }
 }
@@ -221,26 +221,26 @@ void CameraManager::setTargetAngle(float horizontal, float vertical, bool fovAdj
     _fovAdjustment = true;
     _bob.currentFactor = DGCamWalkFactor;
     _bob.currentSpeed = DGCamWalkSpeed;
-    
+
     _fovNormal = _fovPrevious - (float)(DGCamWalkZoomIn / 2);
-    
+
     _bob.state = DGCamWalking;
   }
-  
+
   if (fabs(horizontal - kCurrent) > kEpsilon) {
     // Cancel horizontal motion
     _motionLeft = 0;
     _motionRight = 0;
-    
+
     // Substract n times pi (fix probable double turn)
     GLdouble pi, pos;
     pi = _angleH / (M_PI * 2);
     pos = pi - floor (pi);
     _angleH = pos * 2 * M_PI;
-    
+
     // Extrapolate the coordinates
     _angleHTarget = _toRadians(horizontal, _angleHLimit);
-    
+
     // Treat special case when angle is NORTH
     // TODO: Certain cases aren't supported in this code; ie:
     // slightly rotated left of North, then setting target angle
@@ -249,7 +249,7 @@ void CameraManager::setTargetAngle(float horizontal, float vertical, bool fovAdj
       if (_angleH > M_PI)
         _angleHTarget = M_PI * 2;
     }
-    
+
     // FIXME: This division is related to the amount of configured inertia. Not right.
     if (fabs(_angleHTarget - _angleH) > M_PI) {
       if (_angleH > _angleHTarget) {
@@ -262,25 +262,25 @@ void CameraManager::setTargetAngle(float horizontal, float vertical, bool fovAdj
     else {
       _targetHError = fabs(_angleHTarget - _angleH) / 10.0;
     }
-    
+
     if (_targetHError < 0.02)
       _targetHError = 0.02;
   }
   else {
     _angleHTarget = _angleH;
   }
-  
+
   if (fabs(vertical - kCurrent) > kEpsilon) {
     // Cancel vertical motion
     _motionUp = 0;
     _motionDown = 0;
-    
+
     // Extrapolate the coordinates
     _angleVTarget = _toRadians(vertical, _angleVLimit);;
-    
+
     // FIXME: This division is related to the amount of configured inertia. Not right.
     _targetVError = fabs(_angleVTarget - _angleV) / 10.0;
-    
+
     if (_targetVError < 0.01)
       _targetVError = 0.01;
   }
@@ -288,7 +288,7 @@ void CameraManager::setTargetAngle(float horizontal, float vertical, bool fovAdj
     _angleVTarget = _angleV;
   }
 }
-  
+
 void CameraManager::setHorizontalLimit(float limit) {
   if (!limit)
     _angleHLimit = M_PI * 2.0f;
@@ -302,9 +302,9 @@ void CameraManager::setVerticalLimit(float limit) {
 
 void CameraManager::setViewport(int width, int height) {
   // NOTE: if screen size is changed while in Drag mode, the neutral zone for Free mode isn't updated
-  
+
   _viewport = MakeSize(width, height);
-  
+
   // This forces the new display factor to be applied to the
   // current neutral zone (only in Free mode)
   switch (config.controlMode) {
@@ -317,16 +317,16 @@ void CameraManager::setViewport(int width, int height) {
       setNeutralZone(_freeNeutralZone);
       break;
   }
-  
+
   if (_isInitialized) {
     glViewport(0, 0, (GLint)_viewport.width, (GLint)_viewport.height);
-    
+
     glMatrixMode(GL_PROJECTION);
     glLoadIdentity();
-    
+
     // We need a very close clipping point because the cube is rendered in a small area
     gluPerspective(_fovCurrent, (GLfloat)_viewport.width / (GLfloat)_viewport.height, 0.1f, 10.0f);
-    
+
     glMatrixMode(GL_MODELVIEW);
     glLoadIdentity();
   }
@@ -344,19 +344,19 @@ void CameraManager::beginOrthoView() {
   if (!_inOrthoView && _isInitialized) {
     // Switch to the projection view
     glMatrixMode(GL_PROJECTION);
-    
+
     // Save its current state and load a new identity
     glPushMatrix();
     glLoadIdentity();
-    
+
     // Now we prepare our orthogonal projection
     glOrtho(0, _viewport.width, _viewport.height, 0, -1, 1);
     glMatrixMode(GL_MODELVIEW);
-    
+
     // Note that transformations have been applied to the GL_MODELVIEW
     // so we must reload the identity matrix
     glLoadIdentity();
-    
+
     _inOrthoView = true;
   }
 }
@@ -366,37 +366,12 @@ void CameraManager::endOrthoView() {
     // Go back to the projection view and its previous state
     glMatrixMode(GL_PROJECTION);
     glPopMatrix();
-    
+
     // Leave everything in model view just as it were before
     glMatrixMode(GL_MODELVIEW);
-    
+
     _inOrthoView = false;
   }
-}
-
-void CameraManager::directPan(int xPosition, int yPosition) {
-  int centerX = config.displayWidth >> 1;
-  int centerY = config.displayHeight >> 1;
-  
-  if (xPosition != centerX) {
-    _deltaX = xPosition - centerX;
-  }
-  else {
-    _deltaX = 0;
-  }
-  
-  if (yPosition != centerY) {
-    _deltaY = centerY - yPosition;
-  }
-  else {
-    _deltaY = 0;
-  }
-  
-  float smoothH = config.displayWidth / (_maxSpeed * 10000);
-  float smoothV = config.displayHeight / (_maxSpeed * 10000);
-  
-  _angleH += _toRadians(_deltaX, 1) / smoothH;
-  _angleV += _toRadians(_deltaY, 1) / smoothV;
 }
 
 void CameraManager::init() {
@@ -404,19 +379,19 @@ void CameraManager::init() {
   _canWalk = false;
   _isLocked = false;
   _fovAdjustment = false;
-  
+
   _accelH = 0.0f;
   _accelV = 0.0f;
-  
+
   _angleH = 0.0;
   _angleV = 0.0;
-  
+
   _angleHPrevious = 0.0;
   _angleVPrevious = 0.0;
-  
+
   _angleHLimit = M_PI * 2.0f;
   _angleVLimit = M_PI * 0.5f;
-  
+
   _bob.currentFactor = DGCamBreatheFactor;
   _bob.currentSpeed = DGCamBreatheSpeed;
   _bob.direction = DGCamPause;
@@ -427,42 +402,44 @@ void CameraManager::init() {
   _bob.position = 0.0f;
   _bob.state = DGCamIdle;
   _bob.timer = 0.0f;
-  
+
   _deltaX = 0;
   _deltaY = 0;
-  
+
   _fovCurrent = DGCamFieldOfView;
   _fovNormal = DGCamFieldOfView;
   _fovPrevious = DGCamFieldOfView;
-  
+
   _dragNeutralZone = DGCamDragNeutralZone;
   _freeNeutralZone = DGCamFreeNeutralZone;
-  
+
   _orientation[0] = 0.0f;
   _orientation[1] = 0.0f;
   _orientation[2] = -1.0f;
   _orientation[3] = 0.0f;
   _orientation[4] = 1.0f;
   _orientation[5] = 0.0f;
-  
+
   _position[0] = 0.0f;
   _position[1] = 0.0f;
   _position[2] = 0.0f;
-  
+
   _inertia = 1 / (float)DGCamInertia;
   _inOrthoView = false;
   _isPanning = false;
-  
+
   _motionDown = 0.0f;
   _motionLeft = 0.0f;
   _motionRight = 0.0f;
   _motionUp = 0.0f;
-  
+
   _maxSpeed = 1.0f / (float)DGCamMaxSpeed;
   _speedH = 0.0f;
   _speedV = 0.0f;
   _speedFactor = DGCamSpeedFactor;
-  
+
+  _directPanFlag = false;
+
   _isInitialized = true;
 }
 
@@ -475,7 +452,7 @@ void CameraManager::pan(int xPosition, int yPosition) {
         _deltaX = xPosition - _panRegion.origin.x;
       else _deltaX = 0;
     }
-    
+
     if (yPosition != kCurrent) {
       if (yPosition > _panRegion.size.height)
         _deltaY = _panRegion.size.height - yPosition;
@@ -483,7 +460,7 @@ void CameraManager::pan(int xPosition, int yPosition) {
         _deltaY = _panRegion.origin.y - yPosition;
       else _deltaY = 0;
     }
-    
+
     _speedH = static_cast<float>(fabs((float)_deltaX) / (float)_speedFactor);
     _speedV = static_cast<float>(fabs((float)_deltaY) / (float)_speedFactor);
   }
@@ -502,7 +479,7 @@ void CameraManager::panToTargetAngle() {
       _deltaX = 0;
       _angleHTarget = _angleH;
     }
-    
+
     if (_angleV < (_angleVTarget - _targetVError) || _angleV > (_angleVTarget + _targetVError)) {
       _deltaY = static_cast<int>((_angleVTarget - _angleV) * 360);
       _speedV = static_cast<float>(fabs((float)_deltaY) / ((float)_speedFactor) * 3);
@@ -512,7 +489,7 @@ void CameraManager::panToTargetAngle() {
       _angleVTarget = _angleV;
     }
   }
-  
+
   if (_fovAdjustment) {
     if (_fovNormal == _fovCurrent) {
       _fovAdjustment = false;
@@ -529,9 +506,9 @@ void CameraManager::simulateWalk() {
   if (_canWalk) {
     _bob.currentFactor = DGCamWalkFactor;
     _bob.currentSpeed = DGCamWalkSpeed;
-    
+
     _fovCurrent = _fovNormal + (float)DGCamWalkZoomIn;
-    
+
     _bob.state = DGCamWalking;
   }
 }
@@ -554,26 +531,26 @@ void CameraManager::stopDragging() {
                           (_viewport.height * 0.5) - _dragNeutralZone,
                           (_viewport.width * 0.5) + _dragNeutralZone,
                           (_viewport.height * 0.5) + _dragNeutralZone);
-  
+
   this->pan(config.displayWidth >> 1, config.displayHeight >> 1);
 }
 
 void CameraManager::lock() {
   if (!_isLocked) {
     this->stopPanning();
-    
+
     _motionDown = 0;
     _motionUp = 0;
     _motionLeft = 0;
     _motionRight = 0;
-    
+
     _angleHPrevious = _angleH;
     _angleVPrevious = _angleV;
     _fovPrevious = _fovCurrent;
-    
+
     _angleH = 0.0f;
     _angleV = 0.0f;
-    
+
     _isLocked = true;
   }
 }
@@ -585,32 +562,37 @@ bool CameraManager::isLocked() {
 void CameraManager::unlock() {
   _angleH = _angleHPrevious;
   _angleV = _angleVPrevious;
-  
+
   _isLocked = false;
 }
 
 void CameraManager::update() {
   _isPanning = false;
-  
+
+  if (_isInitialized && _directPanFlag) {
+    _directPanFlag = false;
+    _directPan(_directPanX, _directPanY);
+  }
+
   // Calculate horizontal motion
   if (_deltaX > 0) {
     if (_motionRight < _maxSpeed)
       _motionRight += _speedH;
-    
+
     // Apply inertia to opposite direction
     if (_motionLeft > 0.0f)
       _motionLeft -= _inertia;
-    
+
     _isPanning = true;
   }
   else if (_deltaX < 0) {
     if (_motionLeft < _maxSpeed)
       _motionLeft += _speedH;
-    
+
     // Inertia
     if (_motionRight > 0.0f)
       _motionRight -= _inertia;
-    
+
     _isPanning = true;
   }
   else {
@@ -619,33 +601,33 @@ void CameraManager::update() {
       _motionLeft -= _inertia;
     else
       _motionLeft = 0.0f;
-    
+
     // Decrease rightward motion
     if (_motionRight > 0.0f)
       _motionRight -= _inertia;
     else
       _motionRight = 0.0f;
   }
-  
+
   // Calculate vertical motion
   if (_deltaY > 0) {
     if (_motionDown < _maxSpeed)
       _motionDown += _speedV;
-    
+
     // Apply inertia to opposite direction
     if (_motionUp > 0.0f)
       _motionUp -= _inertia;
-    
+
     _isPanning = true;
   }
   else if (_deltaY < 0) {
     if (_motionUp < _maxSpeed)
       _motionUp += _speedV;
-    
+
     // Inertia
     if (_motionDown > 0.0f)
       _motionDown -= _inertia;
-    
+
     _isPanning = true;
   }
   else {
@@ -654,14 +636,14 @@ void CameraManager::update() {
       _motionDown -= _inertia;
     else
       _motionDown = 0.0f;
-    
+
     // Decrease upward motion
     if (_motionUp > 0.0f)
       _motionUp -= _inertia;
     else
       _motionUp = 0.0f;
   }
-  
+
   // Calculate horizontal acceleration
   if (_deltaX) {
     if (_accelH < 1.0f)
@@ -675,7 +657,7 @@ void CameraManager::update() {
       _accelH = 0.0f;
     }
   }
-  
+
   // Calculate vertical acceleration
   if (_deltaY) {
     if (_accelV < 1.0f)
@@ -688,21 +670,21 @@ void CameraManager::update() {
     else
       _accelV = 0.0f;
   }
-  
+
   // Apply horizontal motion
   if (fabs(_motionLeft) > kEpsilon)
     _angleH -= sin(_accelH) * _motionLeft * config.globalSpeed();
-  
+
   if (fabs(_motionRight) > kEpsilon)
     _angleH += sin(_accelH) * _motionRight * config.globalSpeed();
-  
+
   // Apply vertical motion
   if (fabs(_motionDown) > kEpsilon)
     _angleV += sin(_accelV) * _motionDown * config.globalSpeed();
-  
+
   if (fabs(_motionUp) > kEpsilon)
     _angleV -= sin(_accelV) * _motionUp * config.globalSpeed();
-  
+
   // Limit horizontal rotation
   if (_angleHLimit == M_PI * 2.0f) {
     if (_angleH > (GLfloat)_angleHLimit)
@@ -722,7 +704,7 @@ void CameraManager::update() {
       _motionRight = 0.0f;
     }
   }
-  
+
   // Limit vertical rotation
   if (_angleV > (GLfloat)_angleVLimit) {
     _angleV = (GLfloat)_angleVLimit;
@@ -734,20 +716,20 @@ void CameraManager::update() {
     _motionUp = 0.0f;
     _motionDown = 0.0f;
   }
-  
+
   _orientation[0] = (float)sin(_angleH);
   _orientation[1] = (float)_angleV;
   _orientation[2] = (float)-cos(_angleH);
-  
+
   if (_bob.state != DGCamIdle)
     _calculateBob();
-  
+
   if (_isInitialized) {
     gluLookAt(_position[0], _position[1] + (_bob.displace / 4), _position[2],
               _orientation[0], _orientation[1] + _bob.displace, _orientation[2],
               _orientation[3], _orientation[4], _orientation[5]);
   }
-  
+
   // Displace in x for scare
   /*gluLookAt(_position[0], _position[1], _position[2],
    _orientation[0] + sin(_bob.displace), _orientation[1], _orientation[2],
@@ -758,6 +740,24 @@ void CameraManager::update() {
 // Implementation - Private methods
 ////////////////////////////////////////////////////////////
 
+void CameraManager::_directPan(int xPosition, int yPosition) {
+  int centerX = config.displayWidth >> 1;
+  int centerY = config.displayHeight >> 1;
+  _deltaX = xPosition - centerX;
+  _deltaY = centerY - yPosition;
+
+  float smoothH = config.displayWidth / (_maxSpeed * 10000);
+  float smoothV = config.displayHeight / (_maxSpeed * 10000);
+  _angleH += _toRadians(_deltaX, 1) / smoothH;
+  _angleV += _toRadians(_deltaY, 1) / smoothV;
+}
+
+void CameraManager::setDirectPan(int x, int y) {
+	_directPanFlag = true;
+	_directPanX = x;
+	_directPanY = y;
+}
+
 void CameraManager::_calculateBob() {
   switch (_bob.state) {
     case DGCamBreathing:
@@ -765,7 +765,7 @@ void CameraManager::_calculateBob() {
         _bob.currentFactor--;
       else if (_bob.currentFactor < DGCamBreatheFactor)
         _bob.currentFactor++;
-      
+
       if (_bob.currentSpeed > DGCamBreatheSpeed)
         _bob.currentSpeed--;
       else if (_bob.currentSpeed < DGCamBreatheSpeed)
@@ -785,11 +785,11 @@ void CameraManager::_calculateBob() {
           _bob.state = DGCamBreathing;
         else _bob.state = DGCamIdle;
       }
-      
+
       this->setViewport(config.displayWidth, config.displayHeight);
       break;
   }
-  
+
   switch (_bob.direction) {
     case DGCamPause:
       _bob.timer += 0.1f;
@@ -807,7 +807,7 @@ void CameraManager::_calculateBob() {
         _bob.expireStrength = ((float)((rand() % 2) + 6)) / 10.0f;
         _bob.direction = DGCamExpire;
       }
-      
+
       _bob.displace = static_cast<float>(sin(_bob.position) * cos(_bob.position) / _bob.currentFactor);
       break;
     case DGCamExpire:
@@ -820,7 +820,7 @@ void CameraManager::_calculateBob() {
         else
           _bob.nextPause = (float)((rand() % 3) + 1); // For making the breathing more irregular
       }
-      
+
       _bob.displace = static_cast<float>(sin(_bob.position) * cos(_bob.position) / _bob.currentFactor);
       break;
   }
@@ -835,5 +835,5 @@ GLdouble CameraManager::_toRadians(GLdouble angle, GLdouble limit) {
   GLdouble radians = (angle * limit) / 360.0;
   return radians;
 }
-  
+
 }

--- a/src/CameraManager.h
+++ b/src/CameraManager.h
@@ -84,87 +84,92 @@ class Config;
 
 class CameraManager {
   Config& config;
-  
+
   bool _isInitialized;
   bool _isLocked;
-  
+
   bool _canBreathe;
   bool _canWalk;
-  
+
   bool _fovAdjustment;
-  
+
   float _accelH;
   float _accelV;
-  
+
   GLdouble _angleH;
   GLdouble _angleV;
-  
+
   GLdouble _angleHPrevious;
   GLdouble _angleVPrevious;
-  
+
   GLdouble _angleHTarget;
   GLdouble _angleVTarget;
   GLdouble _targetHError;
   GLdouble _targetVError;
-  
+
   GLdouble _angleHLimit;
   GLdouble _angleVLimit;
-  
+
   DGCameraBob _bob;
-  
+
   GLfloat _fovCurrent;
   GLfloat _fovNormal;
   GLfloat _fovPrevious;
-  
+
   int _deltaX;
   int _deltaY;
-  
+
   float _orientation[6];
   float _position[3];
-  
+
   int _dragNeutralZone;
   int _freeNeutralZone;
-  
+
   Size _viewport;
   Rect _panRegion;
-  
+
   float _inertia;
   bool _inOrthoView;
   bool _isPanning;
-  
+
   float _motionDown;
   float _motionLeft;
   float _motionRight;
   float _motionUp;
-  
+
   float _maxSpeed;
   float _speedH;
   float _speedV;
   int _speedFactor;
-  
+
+  bool _directPanFlag;
+  int _directPanX;
+  int _directPanY;
+
+  void _directPan(int xPosition, int yPosition);
   void _calculateBob();
   GLint _toDegrees(GLdouble angle, GLdouble limit);
   GLdouble _toRadians(GLdouble angle, GLdouble limit);
-  
+
   CameraManager();
   CameraManager(CameraManager const&);
   CameraManager& operator=(CameraManager const&);
   ~CameraManager();
-  
+
 public:
   static CameraManager& instance() {
     static CameraManager cameraManager;
     return cameraManager;
   }
-  
+
   // Checks
-  
+
   bool canBreathe();
   bool canWalk();
   bool isPanning();
-  
+
   // Gets
-  
+
   int angleHorizontal();
   int angleVertical();
   int cursorWhenPanning();
@@ -179,14 +184,14 @@ public:
   float* position(); // Returns the position of the camera
   int speedFactor();
   int verticalLimit();
-  
+
   // Sets
-  
+
   void setAngleHorizontal(float horizontal);
   void setAngleVertical(float vertical);
   void setBreathe(bool enabled);
   void setFieldOfView(float fov);
-  void setHorizontalLimit(float limit);  
+  void setHorizontalLimit(float limit);
   void setInertia(int theInertia);
   void setMaxSpeed(int theSpeed);
   void setNeutralZone(int zone);
@@ -195,29 +200,29 @@ public:
   void setVerticalLimit(float limit);
   void setViewport(int width, int height);
   void setWalk(bool enabled);
-  
+  void setDirectPan(int x, int y);
+
   // State changes
-  
+
   void beginOrthoView();
-  void directPan(int xPosition, int yPosition);
   void init();
   void endOrthoView();
   void pan(int xPosition, int yPosition);
   void panToTargetAngle();
   void simulateWalk();
   void stopPanning();
-  
+
   // For the DRAG mode
   void startDragging(int xPosition, int yPosition); // Recreates the neutral zone
   void stopDragging(); // Resets the neutral zone
-  
+
   void lock();
   bool isLocked();
   void unlock();
-  
+
   void update();
 };
-  
+
 }
 
 #endif // DAGON_CAMERAMANAGER_H_


### PR DESCRIPTION
Attempt at fixing #186 . My theory is that some configurations fire more mouse move events hence calling `directPan` more often, each time adding to `_angleH` and `_angleV`. At least that theory is consistent with the observations in [this comment](https://github.com/Senscape/Dagon/issues/186#issuecomment-270028839), so I'm going with it :smile:

The fix is to only call `directPan` when the camera updates, because that happens at a constant rate. Assuming linear growth of `directPan` (looks like it to me from the code) this does not change the general camera speed, because we would be reducing the number of `directPan`  calls by some factor, but increasing the observed mouse movement by the same factor.

Bottom line is, it works on my Linux test machine and didn't change the camera speed noticably on my Windows machine where fixed mode camera speed was normal.

Lots of whitespace noise in this patch because of the many lines with trailing whitespace that my editor cleaned up.