### PR TITLE
Hotkey changes

### DIFF
--- a/src/Control.cpp
+++ b/src/Control.cpp
@@ -292,7 +292,7 @@ void Control::processKey(int aKey, int eventFlags) {
           }
           break;
         case kKeyTab:
-          _console->toggle();
+          if (config.debugMode) _console->toggle();
           break;
         case kKeySpace:
           if (_hotkeyData[19].enabled && _console->isHidden()) { // 19 is space's index. Is it assigned as a hotkey?

--- a/src/Control.cpp
+++ b/src/Control.cpp
@@ -298,8 +298,6 @@ void Control::processKey(int aKey, int eventFlags) {
           if (_hotkeyData[19].enabled && _console->isHidden()) { // 19 is space's index. Is it assigned as a hotkey?
             script.processCommand(_hotkeyData[19].line);
           }
-          else if (_console->isHidden())
-            config.showHelpers = !config.showHelpers;
           break;
         case 'w':
         case 'W':

--- a/src/Control.cpp
+++ b/src/Control.cpp
@@ -282,13 +282,6 @@ void Control::processKey(int aKey, int eventFlags) {
             else if (_state->current() == StateCutscene) {
               _scene->cancelCutscene();
             }
-            else {
-              if (!_isShuttingDown) {
-                _scene->fadeOut();
-                _shutdownTimer = timerManager.createManual(1.0);
-                _isShuttingDown = true;
-              }
-            }
           }
           break;
         case kKeyTab:
@@ -1025,6 +1018,14 @@ void Control::takeSnapshot() {
   texture.saveToFile(buffer);
 
   config.texCompression = previousTexCompression;
+}
+
+void Control::initiateTerminate() {
+  if (!_isShuttingDown) {
+    _scene->fadeOut();
+    _shutdownTimer = timerManager.createManual(1.0);
+    _isShuttingDown = true;
+  }
 }
 
 void Control::terminate() {

--- a/src/Control.h
+++ b/src/Control.h
@@ -162,6 +162,7 @@ public:
   void walkTo(Object* theTarget);
   void run();
   void takeSnapshot();
+  void initiateTerminate();
   void terminate();
   void update();
   std::vector<Room*> rooms();

--- a/src/SystemLib.h
+++ b/src/SystemLib.h
@@ -57,13 +57,13 @@ static int SystemLibUpdate(lua_State *L) {
 }
 
 static int SystemLibTerminate(lua_State *L) {
-  Control::instance().terminate();
+  Control::instance().initiateTerminate();
   
   return 0;
 }
 
 static int SystemShowHelpers(lua_State *L) {
-	Config::instance().showHelpers = !Config::instance().showHelpers;
+  Config::instance().showHelpers = !Config::instance().showHelpers;
 
   return 0;
 }

--- a/src/SystemLib.h
+++ b/src/SystemLib.h
@@ -62,6 +62,12 @@ static int SystemLibTerminate(lua_State *L) {
   return 0;
 }
 
+static int SystemShowHelpers(lua_State *L) {
+	Config::instance().showHelpers = !Config::instance().showHelpers;
+
+  return 0;
+}
+
 ////////////////////////////////////////////////////////////
 // Static definitions
 ////////////////////////////////////////////////////////////
@@ -72,6 +78,7 @@ static const struct luaL_reg SystemLib [] = {
   {"run", SystemLibRun},
   {"update", SystemLibUpdate},
   {"terminate", SystemLibTerminate},
+  {"toggleHelpers", SystemShowHelpers},
   {NULL, NULL}
 };
 


### PR DESCRIPTION
One bug fix, but primarily saner defaults (imo).

@civanT noticed that pressing tab (opening console) outside of debug mode render user-defined keybindings like space ineffective. The fix is to simply check for debug mode when pressing tab (only way to open the console that I know of, since we removed F5). I never really looked into why toggling the console outside of debug mode is troublesome to begin with. It clearly does something that is not easily reversed by pressing tab again...

Besides that fix, I have removed the default behavior for space and escape keys. Since they can now be bound like many other keys, you can restore the old behavior with
```lua
hotkey(SPACE, "system.toggleHelpers()")
hotkey(ESC, "system.terminate()")
```