### PR TITLE
Support a hand cursor

### DIFF
--- a/src/Control.cpp
+++ b/src/Control.cpp
@@ -411,8 +411,10 @@ void Control::processMouse(int x, int y, int eventFlags) {
       }
 
       if (eventFlags == EventMouseUp) {
-        if (cursorManager.hasAction())
+        if (cursorManager.hasAction()) {
           _processAction();
+          cursorManager.removeHandCursor();
+        }
       }
       break;
 
@@ -428,6 +430,7 @@ void Control::processMouse(int x, int y, int eventFlags) {
       if (eventFlags == EventMouseUp) {
         if (cursorManager.hasAction()) {
           _processAction();
+          cursorManager.removeHandCursor();
         }
       }
       break;
@@ -905,6 +908,7 @@ void Control::switchTo(Object* theTarget) {
                _currentRoom->name().c_str(), current->description().c_str());
       //log.trace(kModControl, "Set window title");
       system.setTitle(title);
+      cursorManager.removeHandCursor();
     }
   }
 

--- a/src/CursorLib.h
+++ b/src/CursorLib.h
@@ -67,6 +67,9 @@ static int CursorLibLoad(lua_State *L) {
   return 0;
 }
 
+extern int CursorLibSetHandCursor(lua_State *L);
+extern int CursorLibGetHandCursor(lua_State *L);
+
 ////////////////////////////////////////////////////////////
 // Static definitions
 ////////////////////////////////////////////////////////////
@@ -77,6 +80,8 @@ static const struct luaL_reg kCursorLib [] = {
   {"fadeIn", CursorLibFadeIn},
   {"fadeOut", CursorLibFadeOut},
   {"load", CursorLibLoad},
+  {"setHandCursor", CursorLibSetHandCursor},
+  {"getHandCursor", CursorLibGetHandCursor},
   {NULL, NULL}
 };
   

--- a/src/CursorManager.cpp
+++ b/src/CursorManager.cpp
@@ -17,7 +17,10 @@
 
 #include "Config.h"
 #include "CursorManager.h"
+#include "Image.h"
 #include "TextureManager.h"
+
+#include <cassert>
 
 namespace dagon {
 
@@ -28,6 +31,7 @@ namespace dagon {
 CursorManager::CursorManager() :
 config(Config::instance())
 {
+  _handCursor = nullptr;
   _hasAction = false;
   _hasImage = false;
   _isDragging = false;
@@ -63,8 +67,17 @@ Action* CursorManager::action() {
   return &_pointerToAction;
 }
 
+Image* CursorManager::handCursor() {
+  return _handCursor;
+}
+
 void CursorManager::bindImage() {
   (*_current).image->bind();
+}
+
+void CursorManager::bindHandCursor() {
+  assert(_handCursor != nullptr);
+  _handCursor->texture()->bind();
 }
 
 float* CursorManager::arrayOfCoords() {
@@ -77,6 +90,10 @@ bool CursorManager::hasAction() {
 
 bool CursorManager::hasImage() {
   return _hasImage;
+}
+
+bool CursorManager::hasHandCursor() {
+  return _handCursor != nullptr;
 }
 
 bool CursorManager::isDragging() {
@@ -108,6 +125,10 @@ void CursorManager::removeAction() {
   _hasAction = false;
 }
 
+void CursorManager::removeHandCursor() {
+  _handCursor = nullptr;
+}
+
 void CursorManager::setDragging(bool flag) {
   if (flag) {
     this->_set(kCursorDrag);
@@ -130,6 +151,14 @@ void CursorManager::setAction(Action theAction) {
 
 void CursorManager::setCursor(int typeOfCursor) {
   this->_set(typeOfCursor);
+}
+
+void CursorManager::setHandCursor(Image* img) {
+  _handCursor = img;
+
+  if (!_handCursor->texture()->isLoaded()) {
+    _handCursor->texture()->load();
+  }
 }
 
 void CursorManager::setSize(int size) {

--- a/src/CursorManager.h
+++ b/src/CursorManager.h
@@ -33,6 +33,7 @@ namespace dagon {
 
 class Config;
 class Texture;
+class Image;
 
 typedef struct {
   int type;
@@ -50,6 +51,7 @@ class CursorManager : public Object {
   
   std::vector<DGCursorData> _arrayOfCursors;
   std::vector<DGCursorData>::iterator _current;
+  Image* _handCursor;
   float _arrayOfCoords[8];
   int _half;
   bool _hasAction;
@@ -76,19 +78,24 @@ public:
   }
   
   Action* action();
+  Image* handCursor();
   void bindImage();
+  void bindHandCursor();
   float* arrayOfCoords();
   bool hasAction();
   bool hasImage();
+  bool hasHandCursor();
   bool isDragging();
   void load(int typeOfCursor, const char* imageFromFile, int offsetX = 0, int offsetY = 0);
   bool onButton();
   Point position();
   void removeAction();
+  void removeHandCursor();
   void setDragging(bool flag);
   void setOnButton(bool flag);
   void setAction(Action theAction);
   void setCursor(int typeOfCursor);
+  void setHandCursor(Image* img);
   void setSize(int size);
   void updateCoords(int x, int y);
 };

--- a/src/Interface.cpp
+++ b/src/Interface.cpp
@@ -61,8 +61,17 @@ void Interface::drawCursor() {
   
   // Mouse cursor
   if (cursorManager.isEnabled()) {
-    if (cursorManager.hasImage()) { // A bitmap cursor is currently set
+    if (cursorManager.hasImage()) {
       cursorManager.updateFade(); // Process fade (supported only with bitmaps)
+    }
+
+    if (cursorManager.hasHandCursor()) {
+      cursorManager.bindHandCursor();
+      renderManager.setAlpha(cursorManager.fadeLevel());
+      renderManager.drawSlide(cursorManager.arrayOfCoords());
+    }
+
+    if (cursorManager.hasImage()) { // A bitmap cursor is currently set
       cursorManager.bindImage();
       renderManager.setAlpha(cursorManager.fadeLevel());
       renderManager.drawSlide(cursorManager.arrayOfCoords());

--- a/src/Script.cpp
+++ b/src/Script.cpp
@@ -1056,5 +1056,28 @@ void Script::_registerGlobals() {
   luaL_register(_L, NULL, globalLibs);
   lua_pop(_L, 1);
 }
+
+int CursorLibSetHandCursor(lua_State *L) {
+  if (lua_isnil(L, 1)) {
+    CursorManager::instance().removeHandCursor();
+  } else if (DGCheckProxy(L, 1) == kObjectImage) {
+    Image* cursor = ProxyToImage(L, 1);
+    CursorManager::instance().setHandCursor(cursor);
+  } else {
+    //TODO: error message
+  }
+  
+  return 0;
+}
+
+int CursorLibGetHandCursor(lua_State *L) {
+  if (CursorManager::instance().hasHandCursor()) {
+    lua_pushstring(L, CursorManager::instance().handCursor()->name().c_str());
+  } else {
+    lua_pushnil(L);
+  }
+  
+  return 1;
+}
   
 }


### PR DESCRIPTION
Implements the suggestion described in #192 . It's basically a separate image that can be displayed behind the existing cursor. The programming interface is as described in #192 , with the exception that `cursor.getHandCursor()` returns the name of the Image object used with `cursor.setHandCursor` - not the Image object itself. This decision was made because of use-cases like `cursor.setHandCursor(Image("some_item.png"))` where the developer doesn't have an Image object to compare the return value of `cursor.getHandCursor()` to. So for code like
```lua
i = Image("some_item.png")
cursor.setHandCursor(i)
```
You will have to do either `cursor.getHandCursor() == "some_item.png"` or `cursor.getHandCursor() == i:name()` to check which item the player is holding. 