### PR TITLE
on(Un)hover callback for Spots

### DIFF
--- a/src/Language.h
+++ b/src/Language.h
@@ -99,6 +99,7 @@
 #define kString14013 "Syntax error"
 #define kString14014 "Function expected as second parameter in register()"
 #define kString14015 "Bad configuration file"
+#define kString14016 "Expected function parameter"
 
 // Font module
 #define kString15001 "Initializing font manager..."

--- a/src/Scene.cpp
+++ b/src/Scene.cpp
@@ -205,6 +205,10 @@ bool Scene::scanSpots() {
         }
         
         if (!foundAction) {
+          if (_lastHoveredSpot && _lastHoveredSpot->hasOnUnhoverCallback()) {
+            Script::instance().processCallback(_lastHoveredSpot->onUnhoverCallback(),
+                                               _lastHoveredSpot->luaObject());
+          }
           _lastHoveredSpot = nullptr;
           cursorManager.removeAction();
           

--- a/src/Scene.cpp
+++ b/src/Scene.cpp
@@ -26,6 +26,7 @@
 #include "RenderManager.h"
 #include "Room.h"
 #include "Scene.h"
+#include "Script.h"
 #include "Spot.h"
 #include "Texture.h"
 #include "VideoManager.h"
@@ -51,6 +52,7 @@ videoManager(VideoManager::instance())
   _canDrawSpots = false;
   _isCutsceneLoaded = false;
   _isSplashLoaded = false;
+  _lastHoveredSpot = nullptr;
 }
 
 ////////////////////////////////////////////////////////////
@@ -193,13 +195,17 @@ bool Scene::scanSpots() {
             if (color == spot->color()) {
               cursorManager.setAction(*spot->action());
               foundAction = true;
-              
+              if (_lastHoveredSpot != spot && spot->hasOnHoverCallback()) {
+                Script::instance().processCallback(spot->onHoverCallback(), spot->luaObject());
+              }
+              _lastHoveredSpot = spot;
               break;
             }
           } while (currentNode->iterateSpots());
         }
         
         if (!foundAction) {
+          _lastHoveredSpot = nullptr;
           cursorManager.removeAction();
           
           if (cameraManager.isPanning())

--- a/src/Scene.h
+++ b/src/Scene.h
@@ -31,6 +31,7 @@ class Config;
 class CursorManager;
 class RenderManager;
 class Room;
+class Spot;
 class State;
 class Texture;
 class VideoManager;
@@ -52,6 +53,8 @@ class Scene {
   Room* _currentRoom;
   Texture* _cutsceneTexture;
   Texture* _splashTexture;
+
+  Spot* _lastHoveredSpot;
   
   bool _canDrawSpots; // This bool is used to make checks faster
   bool _isCutsceneLoaded;

--- a/src/Spot.cpp
+++ b/src/Spot.cpp
@@ -51,6 +51,7 @@ Spot::Spot(std::vector<int> withArrayOfCoordinates,
   _yOrigin = 0;
   _zOrder = 0; // For future use
   _hasHoverCallback = false;
+  _hasUnhoverCallback = false;
   this->setType(kObjectSpot);
 }
 
@@ -101,6 +102,10 @@ bool Spot::isPlaying() {
 
 bool Spot::hasOnHoverCallback() const {
   return _hasHoverCallback;
+}
+
+bool Spot::hasOnUnhoverCallback() const {
+  return _hasUnhoverCallback;
 }
 
 ////////////////////////////////////////////////////////////
@@ -160,6 +165,11 @@ std::string Spot::stringifyCoords() const {
 int Spot::onHoverCallback() const {
   assert(_hasHoverCallback);
   return _luaHoverCallback;
+}
+
+int Spot::onUnhoverCallback() const {
+  assert(_hasUnhoverCallback);
+  return _luaUnhoverCallback;
 }
 
 ////////////////////////////////////////////////////////////
@@ -223,6 +233,11 @@ void Spot::setVolume(float theVolume) {
 void Spot::setOnHoverCallback(int luaRegRef) {
   _luaHoverCallback = luaRegRef;
   _hasHoverCallback = true;
+}
+
+void Spot::setOnUnhoverCallback(int luaRegRef) {
+  _luaUnhoverCallback = luaRegRef;
+  _hasUnhoverCallback = true;
 }
 
 ////////////////////////////////////////////////////////////

--- a/src/Spot.cpp
+++ b/src/Spot.cpp
@@ -16,6 +16,7 @@
 ////////////////////////////////////////////////////////////
 
 #include <algorithm>
+#include <cassert>
 #include <cstdlib>
 #include <iterator>
 #include <sstream>
@@ -49,6 +50,7 @@ Spot::Spot(std::vector<int> withArrayOfCoordinates,
   _xOrigin = 0;
   _yOrigin = 0;
   _zOrder = 0; // For future use
+  _hasHoverCallback = false;
   this->setType(kObjectSpot);
 }
 
@@ -95,6 +97,10 @@ bool Spot::hasVideo() {
 
 bool Spot::isPlaying() {
   return _isPlaying;
+}
+
+bool Spot::hasOnHoverCallback() const {
+  return _hasHoverCallback;
 }
 
 ////////////////////////////////////////////////////////////
@@ -149,6 +155,11 @@ std::string Spot::stringifyCoords() const {
   std::copy(_arrayOfCoordinates.begin(), std::prev(_arrayOfCoordinates.end()),
             std::ostream_iterator<int>(coordStr, ", "));
   return coordStr.str() + std::to_string(_arrayOfCoordinates.back());
+}
+
+int Spot::onHoverCallback() const {
+  assert(_hasHoverCallback);
+  return _luaHoverCallback;
 }
 
 ////////////////////////////////////////////////////////////
@@ -207,6 +218,11 @@ void Spot::setVideo(Video* aVideo) {
 
 void Spot::setVolume(float theVolume) {
   _volume = theVolume;
+}
+
+void Spot::setOnHoverCallback(int luaRegRef) {
+  _luaHoverCallback = luaRegRef;
+  _hasHoverCallback = true;
 }
 
 ////////////////////////////////////////////////////////////

--- a/src/Spot.h
+++ b/src/Spot.h
@@ -61,6 +61,7 @@ class Spot : public Object {
   bool hasTexture();
   bool hasVideo();
   bool isPlaying();
+  bool hasOnHoverCallback() const;
   
   // Gets
   Action* action();
@@ -74,6 +75,7 @@ class Spot : public Object {
   Video* video();
   float volume();
   std::string stringifyCoords() const;
+  int onHoverCallback() const;
   
   // Sets
   void setAction(Action* anAction);
@@ -83,6 +85,7 @@ class Spot : public Object {
   void setTexture(Texture* aTexture);
   void setVideo(Video* aVideo);
   void setVolume(float theVolume);
+  void setOnHoverCallback(int luaRegRef);
   
   // State changes
   void play();
@@ -110,6 +113,8 @@ class Spot : public Object {
   int _xOrigin;
   int _yOrigin;
   int _zOrder; // For future use
+  bool _hasHoverCallback;
+  int _luaHoverCallback;
   
   Spot(const Spot&);
   void operator=(const Spot&);

--- a/src/Spot.h
+++ b/src/Spot.h
@@ -62,6 +62,7 @@ class Spot : public Object {
   bool hasVideo();
   bool isPlaying();
   bool hasOnHoverCallback() const;
+  bool hasOnUnhoverCallback() const;
   
   // Gets
   Action* action();
@@ -76,6 +77,7 @@ class Spot : public Object {
   float volume();
   std::string stringifyCoords() const;
   int onHoverCallback() const;
+  int onUnhoverCallback() const;
   
   // Sets
   void setAction(Action* anAction);
@@ -86,6 +88,7 @@ class Spot : public Object {
   void setVideo(Video* aVideo);
   void setVolume(float theVolume);
   void setOnHoverCallback(int luaRegRef);
+  void setOnUnhoverCallback(int luaRegRef);
   
   // State changes
   void play();
@@ -115,6 +118,8 @@ class Spot : public Object {
   int _zOrder; // For future use
   bool _hasHoverCallback;
   int _luaHoverCallback;
+  bool _hasUnhoverCallback;
+  int _luaUnhoverCallback;
   
   Spot(const Spot&);
   void operator=(const Spot&);

--- a/src/SpotProxy.h
+++ b/src/SpotProxy.h
@@ -306,6 +306,22 @@ public:
 
     return 0;
   }
+
+  int onUnhover(lua_State *L) {
+    if (!lua_isfunction(L, 1)) {
+      Log::instance().trace(kModScript, kString14016);
+      return 0;
+    }
+
+    if (s->hasOnUnhoverCallback())
+      luaL_unref(L, LUA_REGISTRYINDEX, s->onUnhoverCallback());
+
+    lua_pushvalue(L, 1); // push the callback on the stack
+    int ref = luaL_ref(L, LUA_REGISTRYINDEX); // pop callback and return a registry reference to it
+    s->setOnUnhoverCallback(ref);
+
+    return 0;
+  }
   
   // Destructor
   ~SpotProxy() { delete s; }
@@ -330,6 +346,7 @@ Luna<SpotProxy>::RegType SpotProxy::methods[] = {
   method(SpotProxy, play),
   method(SpotProxy, stop),
   method(SpotProxy, onHover),
+  method(SpotProxy, onUnhover),
   {0,0}
 };
   

--- a/src/SpotProxy.h
+++ b/src/SpotProxy.h
@@ -290,6 +290,22 @@ public:
     s->stop();
     return 0;
   }
+
+  int onHover(lua_State *L) {
+    if (!lua_isfunction(L, 1)) {
+      Log::instance().trace(kModScript, kString14016);
+      return 0;
+    }
+
+    if (s->hasOnHoverCallback())
+      luaL_unref(L, LUA_REGISTRYINDEX, s->onHoverCallback());
+
+    lua_pushvalue(L, 1); // push the callback on the stack
+    int ref = luaL_ref(L, LUA_REGISTRYINDEX); // pop callback and return a registry reference to it
+    s->setOnHoverCallback(ref);
+
+    return 0;
+  }
   
   // Destructor
   ~SpotProxy() { delete s; }
@@ -313,6 +329,7 @@ Luna<SpotProxy>::RegType SpotProxy::methods[] = {
   method(SpotProxy, isPlaying),
   method(SpotProxy, play),
   method(SpotProxy, stop),
+  method(SpotProxy, onHover),
   {0,0}
 };
   


### PR DESCRIPTION
With this change it's now possible to assign a callback for the hover event on Spots, from Lua.

Example use:
````lua
mySpot:onHover(function()
  -- do interesting stuff here
  self:onHover(function() -- overwrite the hover event when hovered
                          -- note that "self" refers to the Spot that was hovered
                          -- useful if assigning the same function to different Spots
      print("hover-ception")
    end)
end)
````