### PR TITLE
Hover fixes

### DIFF
--- a/src/Scene.cpp
+++ b/src/Scene.cpp
@@ -52,7 +52,7 @@ videoManager(VideoManager::instance())
   _canDrawSpots = false;
   _isCutsceneLoaded = false;
   _isSplashLoaded = false;
-  _lastHoveredSpot = nullptr;
+  _hoveredSpot = nullptr;
 }
 
 ////////////////////////////////////////////////////////////
@@ -195,21 +195,27 @@ bool Scene::scanSpots() {
             if (color == spot->color()) {
               cursorManager.setAction(*spot->action());
               foundAction = true;
-              if (_lastHoveredSpot != spot && spot->hasOnHoverCallback()) {
-                Script::instance().processCallback(spot->onHoverCallback(), spot->luaObject());
+              if (_hoveredSpot != spot) {
+                if (_hoveredSpot && _hoveredSpot->hasOnUnhoverCallback()) {
+                  Script::instance().processCallback(_hoveredSpot->onUnhoverCallback(),
+                                                     _hoveredSpot->luaObject());
+                }
+                _hoveredSpot = spot;
+                if (spot->hasOnHoverCallback()) {
+                  Script::instance().processCallback(spot->onHoverCallback(), spot->luaObject());
+                }
               }
-              _lastHoveredSpot = spot;
               break;
             }
           } while (currentNode->iterateSpots());
         }
         
         if (!foundAction) {
-          if (_lastHoveredSpot && _lastHoveredSpot->hasOnUnhoverCallback()) {
-            Script::instance().processCallback(_lastHoveredSpot->onUnhoverCallback(),
-                                               _lastHoveredSpot->luaObject());
+          if (_hoveredSpot && _hoveredSpot->hasOnUnhoverCallback()) {
+            Script::instance().processCallback(_hoveredSpot->onUnhoverCallback(),
+                                               _hoveredSpot->luaObject());
           }
-          _lastHoveredSpot = nullptr;
+          _hoveredSpot = nullptr;
           cursorManager.removeAction();
           
           if (cameraManager.isPanning())

--- a/src/Scene.h
+++ b/src/Scene.h
@@ -54,7 +54,7 @@ class Scene {
   Texture* _cutsceneTexture;
   Texture* _splashTexture;
 
-  Spot* _lastHoveredSpot;
+  Spot* _hoveredSpot;
   
   bool _canDrawSpots; // This bool is used to make checks faster
   bool _isCutsceneLoaded;


### PR DESCRIPTION
Make sure to trigger onUnhover even if the cursor moves from one spot to
another without leaving a spot (e.g. there's an overlap or you're moving
your mouse wicked fast)