### PR TITLE
Fix a bug with loading (mostly affected nodes)

### DIFF
--- a/src/Script.cpp
+++ b/src/Script.cpp
@@ -368,7 +368,11 @@ int Script::_globalNewIndex(lua_State *L) {
       return 0;
     }
 
-    Control::instance().objMap[obj] = hash;
+    if (Control::instance().objMap.find(obj) == Control::instance().objMap.end())
+      Control::instance().objMap[obj] = hash;
+    else
+      Log::instance().warning(kModScript, "Detected %s is an alias", varName);
+
     Control::instance().invObjMap[hash] = obj;
   }
 


### PR DESCRIPTION
If a node is aliased, the last registered alias would be saved. This is a problem since that alias is rarely available when loading. We should save its first name instead since that name is more likely to be present when loading.
This applies to all objects we support saving, but nodes in particular are subject to aliasing.